### PR TITLE
Correcting Norwegian locale example in locales.md

### DIFF
--- a/source/locales.md
+++ b/source/locales.md
@@ -34,7 +34,7 @@ options are:
     fr_FR    French               France                                     fr   FR  
     it_IT    Italian              Italy                                      it   IT  
     nl_NL    Dutch                Netherlands                                nl   NL  
-    no_NO    Norwegian            Norway                                     no   NO  
+    nb_NO    Norwegian Bokmål     Norway                                     nb   NO  
     pl_PL    Polish               Poland                                     pl   PL  
     pt_PT    Portuguese           Portugal                                   pt   PT  
     ru_RU    Russian              Russian Federation                         ru   RU  


### PR DESCRIPTION
The locale no_NO is deprecated - only nb_NO (and nn_NO) should be used. We don't want the examples to be wrong, do we ;-)

PS! I'm just blind or isn't there a doc page about translating Bolt yet?

PS2! Sorry about the branch name, but Github created it without asking.
