### PR TITLE
Fixed download link in docs

### DIFF
--- a/view/index.twig
+++ b/view/index.twig
@@ -64,7 +64,7 @@
             </nav>
             <h1 id="logo"><img src="{{prefix}}/view/images/bolt.png" width='200' alt="BoltCM" /></h1>
             <h2 class="payoff">Sophisticated, Lightweight and Simple</h2>
-            <a class="button download show-for-large-up" href="/pages/download">
+            <a class="button download show-for-large-up" href="https://bolt.cm/pages/download">
                 <span class="desktop">Download Bolt</span><span class="mobile">View download options</span>
                 <span class="sub">Current version v 2.0</span>
             </a>


### PR DESCRIPTION
When in docs the link to the download page is on the wrong subdomain. This should fix it.

Regards,
Frederik
