### PR TITLE
added .woff2 access permission into nginx configuration

### DIFF
--- a/source/installation.md
+++ b/source/installation.md
@@ -331,7 +331,7 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
-    location ~* \.(?:ico|css|js|gif|jpe?g|png|ttf|woff)$ {
+    location ~* \.(?:ico|css|js|gif|jpe?g|png|ttf|woff|woff2)$ {
         access_log off;
         expires 30d;
         add_header Pragma public;


### PR DESCRIPTION
Bolt back-end loads Source Sans with woff2 extension.