### PR TITLE
Assign return value from app.config.set() to a variable so it's not output to the browser

### DIFF
--- a/source/howto/boilerplate-for-multilingual-websites.md
+++ b/source/howto/boilerplate-for-multilingual-websites.md
@@ -31,7 +31,7 @@ Boilerplate for Multilingual Websites
 
 {# --- set the locale for international dates --- #}
 
-{{ app.config.set('general/locale', locales[language]) }}
+{% set ret = app.config.set('general/locale', locales[language]) %}
 {{ app.initLocale() }}
 
 {# --- set the language for the Labels extension --- #}

--- a/source/howto/building-multilingual-websites.md
+++ b/source/howto/building-multilingual-websites.md
@@ -363,7 +363,7 @@ languages to locales.
 Set the correct locale and call the function `initLocale` to apply a new locale.
 
 ```
-{{ app.config.set('general/locale', locales[language]) }}
+{% set ret = app.config.set('general/locale', locales[language]) %}
 {{ app.initLocale() }}
 ```
 


### PR DESCRIPTION
Fixes https://github.com/bolt/bolt/issues/3414