### PR TITLE
Local extensions do appear in Extend page

### DIFF
--- a/source/howto/installing-local-extensions.md
+++ b/source/howto/installing-local-extensions.md
@@ -10,8 +10,6 @@ There are a couple of caveats:
   - Must be located in `{web_root}/extensions/local/{author_name}/{extension_name}/`
   - They **will** be automatically enabled if the directories above exist and
     contain `init.php` and `Extension.php`
-  - They **will not** appear in the Extend page in the *"Your Currently
-    Installed Extensions"* section on your Bolt site
 
 Step 1
 ------
@@ -58,3 +56,5 @@ use Bolt\Extension\MyName\MyExtension\Extension;
 
 $app['extensions']->register(new Extension($app));
 ```
+- Your extension should now appear in the Extend page in the *"Your Currently
+    Installed Extensions"* section on your Bolt site


### PR DESCRIPTION
After following the steps of the How To document 'Installing Local Extensions' i _could_ actually see my extension in the Extend page.

I removed the statement that local extensions do not appear in the Extend page and added an additional sentence in Step 3 stating the opposite.