### PR TITLE
add tip to autload local extension

### DIFF
--- a/source/extensions/config.md
+++ b/source/extensions/config.md
@@ -58,8 +58,7 @@ and namespaces. There are three files you need to edit, `composer.json`,
 The above steps will get you started, and below is some more indepth information
 about the configuration.
 
-<p class="note"><strong>Tip:</strong> As noted in <a href="/howto/installing-local-extensions">Installing Local Extensions</a>, local extensions have no autoloader by default. Use <code>include_once</code> in Extension.php to load any additional class files you may create. If you move the extension to an external repository, remove the <code>include_once</code> lines.</p>
-
+<p class="note"><strong>Tip:</strong> As noted in <a href="/howto/installing-local-extensions">Installing Local Extensions</a>, local extensions need some caution.</p>
 
 ### The JSON file
 

--- a/source/howto/installing-local-extensions.md
+++ b/source/howto/installing-local-extensions.md
@@ -6,10 +6,11 @@ extensions site.
 
 There are a couple of caveats:
 
-  - There is no autoloader by default
-  - Must be located in `{web_root}/extensions/local/{author_name}/{extension_name}/`
+  - Autoloading is NOT guaranteed unless you have a properly defined composer.json file
+  - MUST be located in `{web_root}/extensions/local/{author_name}/{extension_name}/`
   - They **will** be automatically enabled if the directories above exist and
     contain `init.php` and `Extension.php`
+  - Updates are NOT available though the web UI.
 
 Step 1
 ------
@@ -22,6 +23,43 @@ Where:
  - `{extension_name}` is a lower-case, space-less name
 
 Step 2
+------
+
+Create a `composer.json` to guarantee autoloding as:
+
+```
+{
+    "name": "{author_name}/{extension_name}",
+    "description": "A description about your extension should go here.",
+    "type": "bolt-extension",
+    "require": {
+        "bolt/bolt": ">=2.0.0,<3.0.0"
+    },
+    "authors": [
+        {
+            "name": "Your Name",
+            "email": "your@email.com"
+        }
+    ],
+    "autoload": {
+        "files": [
+            "init.php"
+        ],
+        "psr-4": {
+            "Bolt\\Extension\\MyName\\MyExtension\\": ["", "src/"]
+        }
+    }
+}
+
+```
+Where:
+ - `{author_name}` is a lower-case, space-less name
+ - `{extension_name}` is a lower-case, space-less name
+ - `MyName` is a camel-case, space-less name
+ - `MyExtension` is a camel-case, space-less name
+
+
+Step 3
 ------
 
 Create an `Extension.php` file that contains something like this:
@@ -46,7 +84,7 @@ class Extension extends \Bolt\BaseExtension
 }
 ```
 
-Step 3
+Step 4
 ------
 
 Create an `init.php` file that contains something like this:


### PR DESCRIPTION
after some minutes to discover why local extensions not been autoloaded... 

why the composer not load my local extension classes? I created the composer file and execute the `composer dump-autload`, but why doesn't load?

So, :boom: I had an idea, I did add the vendor/autload.php in my init.php file from my local extension and it solved my problem.

It works good for me and it can help many people which have local extension!!

If I forgot to change others places, tell me, please!!