### PR TITLE
Update extension PHPUnit docs

### DIFF
--- a/source/extensions/testing.md
+++ b/source/extensions/testing.md
@@ -2,7 +2,7 @@ Extensions: Testing and debugging
 =================================
 
 It's essential that by the time you submit your extension to the Bolt
-Marketplace you have tested your extension as thouroughly as possible. To help
+Marketplace you have tested your extension as thoroughly as possible. To help
 you do this we've put together some suggested workflows that will help you to
 both get started, develop and then deploy your extension.
 
@@ -113,7 +113,7 @@ Once you have a public url for the Git repository then you can submit your
 extension to the Bolt Marketplace. To do so visit [extensions.bolt.cm][ext], sign up for an account
 if you need to and then submit your extension.
 
-If everything looks ok at this point you will be able to see your extension
+If everything looks OK at this point you will be able to see your extension
 listed on the marketplace.
 
 ### Approved Builds and Stable Versions
@@ -135,7 +135,7 @@ git tag 1.0
 git push --tags
 ```
 
-You should ensure that you have throughly tested each released version, we'd
+You should ensure that you have thoroughly tested each released version, we'd
 recommend following [semantic version numbers][semver]</a>
 for your releases.
 

--- a/source/extensions/unit-testing.md
+++ b/source/extensions/unit-testing.md
@@ -64,6 +64,84 @@ Step 2: Create a phpunit.xml.dist file
 The example file below configures `PHPUnit`, place it in the root of the project
 and adjust where needed.
 
+<p class="meta">
+    <strong>Bolt 2.2.6</strong><br>
+    The following phpunit.xml.dist is only available in Bolt 2.2.6 and later, 
+    for older versions see the example below this one.
+</p>
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <listeners>
+        <listener file="vendor/bolt/bolt/tests/phpunit/BoltListener.php" class="Bolt\Tests\BoltListener">
+           <arguments>
+              <!-- Configuration files. Can be either .yml or .yml.dist files -->
+              <!-- Locations can be relative to TEST_ROOT directory, the Bolt directory, or an absolute path -->
+              <array>
+                  <element key="config">
+                      <string>vendor/bolt/bolt/app/config/config.yml.dist</string>
+                  </element>
+                  <element key="contenttypes">
+                      <string>vendor/bolt/bolt/app/config/contenttypes.yml.dist</string>
+                  </element>
+                  <element key="menu">
+                      <string>vendor/bolt/bolt/app/config/menu.yml.dist</string>
+                  </element>
+                  <element key="permissions">
+                      <string>vendor/bolt/bolt/app/config/permissions.yml.dist</string>
+                  </element>
+                  <element key="routing">
+                      <string>vendor/bolt/bolt/app/config/routing.yml.dist</string>
+                  </element>
+                  <element key="taxonomy">
+                      <string>vendor/bolt/bolt/app/config/taxonomy.yml.dist</string>
+                  </element>
+              </array>
+              <!-- Theme directory. Can be relative to TEST_ROOT directory, the Bolt directory, or an absolute path -->
+              <array>
+                  <element key="theme">
+                      <string>theme/base-2014</string>
+                  </element>
+              </array>
+              <!-- The Bolt SQLite database, leave empty to use the one bundled with Bolt's repository -->
+              <!-- Location can be relative to TEST_ROOT directory, the Bolt directory, or an absolute path -->
+              <array>
+                  <element key="boltdb">
+                      <string>vendor/bolt/bolt/tests/phpunit/unit/resources/db/bolt.db</string>
+                  </element>
+              </array>
+              <!-- Reset the cache and test temporary directories -->
+              <boolean>true</boolean>
+              <!-- Create timer output in app/cache/phpunit-test-timer.txt -->
+              <boolean>true</boolean>
+           </arguments>
+        </listener>
+    </listeners>
+</phpunit>
+```
+
+The important settings you may need to modify are the arguments passed into the PHPUnit listener.
+With these settings you can specify a pre-built set of configuration files, theme, and/or Sqlite database.
+
+<p class="meta">
+    <strong>Bolt <= 2.2.5</strong><br>
+    The following functionality is for versoins of Bolt before 2.2.5.
+</p>
 ```
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"

--- a/source/extensions/unit-testing.md
+++ b/source/extensions/unit-testing.md
@@ -39,7 +39,11 @@ test directory to suit.
             "Bolt\\Extensions\\Bolt\\Colourpicker\\Tests\\": "tests"
         }
     },
-
+    "autoload-dev" : {
+        "psr-4" : {
+            "Bolt\\Tests\\" : "vendor/bolt/bolt/tests/phpunit/unit/"
+        }
+    },
     "extra": {
         "bolt-assets": "assets",
         "bolt-screenshots": [

--- a/source/extensions/unit-testing.md
+++ b/source/extensions/unit-testing.md
@@ -134,9 +134,11 @@ and adjust where needed.
     </listeners>
 </phpunit>
 ```
+**Note:** We refer to a `tests/bootstrap.php` file that doesn't exist yet.
 
-The important settings you may need to modify are the arguments passed into the PHPUnit listener.
-With these settings you can specify a pre-built set of configuration files, theme, and/or Sqlite database.
+**Note:** The listener is optional, it will copy in an Sqlite database with table 
+structure matching current Bolt tests, and it will also copy in the specified 
+theme, and configuration files which is helpful if you're writing unit tests. 
 
 <p class="meta">
     <strong>Bolt <= 2.2.5</strong><br>
@@ -177,23 +179,40 @@ With these settings you can specify a pre-built set of configuration files, them
 </phpunit>
 ```
 
-**Note:** We refer to a `tests/bootsrap.php` file that doesn't exist yet.
+**Note:** We refer to a `tests/bootstrap.php` file that doesn't exist yet.
 
 **Note:** The listener is optional, it will copy in an Sqlite database with table 
 structure matching current Bolt tests, and it will also copy in the specified 
-theme, which is helpful if you're writing UI tests. 
+theme, which is helpful if you're writing unit tests. 
 
 Step 3: Create a bootstrap.php file
 -----------------------------------
 
-This sets up a tmp dir to store required Bolt files and sets a couple of
+This sets up a tmp directory to store required Bolt files and sets a couple of
 constants.
 
 Create the file `tests/bootstrap.php` containing the following:
+<p class="meta">
+    <strong>Bolt 2.2.6</strong><br>
+    The following phpunit.xml.dist is only available in Bolt 2.2.6 and later, 
+    for older versions see the example below this one.
+</p>
 
 ```
 <?php
+include_once __DIR__ . '/../vendor/bolt/bolt/tests/phpunit/bootstrap.php';
 
+define('EXTENSION_AUTOLOAD',  realpath(dirname(__DIR__) . '/vendor/autoload.php'));
+
+require_once EXTENSION_AUTOLOAD;
+```
+<p class="meta">
+    <strong>Bolt <= 2.2.5</strong><br>
+    The following functionality is for versoins of Bolt before 2.2.5.
+</p>
+
+```
+<?php
 define('TEST_ROOT',    __DIR__ . '/tmp');
 define('PHPUNIT_ROOT', realpath(dirname(__DIR__) . '/vendor/bolt/bolt/tests/phpunit/unit/'));
 define('BOLT_AUTOLOAD',  realpath(dirname(__DIR__) . '/vendor/autoload.php'));


### PR DESCRIPTION
This is the updated extension unit testing documentation that applies to Bolt 2.2.6 and the upcoming 2.3.0.

Reference PRs:
https://github.com/bolt/bolt/pull/3850
https://github.com/bolt/bolt/pull/3870
https://github.com/bolt/bolt/pull/3874