### PR TITLE
Fix samples of config value access

### DIFF
--- a/source/templatetags.md
+++ b/source/templatetags.md
@@ -577,12 +577,12 @@ Available variables in Twig
 ### app
 
 ```
-{{ app.config.general.sitename }}
+{{ app.config.get('general/sitename') }}
 ```
 
 
 ```
-{{ dump(app.config.general) }}
+{{ dump(app.config.get('general') }}
 ```
 
 For more info on `app`, see the chapter on [Bolt Internals](/internals/bolt-internals).


### PR DESCRIPTION
direct access to a config value with the dot notation no longer works ( ie : {{ app.config.general.xxx }}  ) , the get() method must be used.