### PR TITLE
Initial proposal for a multi version build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cache/*
 .DS_*
 node_modules
 bower_components
+version/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cache/*
 node_modules
 bower_components
 version/
+versions.yml

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "jbroadway/urlify": "dev-master",
         "michelf/php-smartypants": "1.6.0-beta1",
         "symfony/finder": "^2.8",
+        "symfony/console": "^2.4",
         "symfony/var-dumper": "^2.8",
         "symfony/yaml": "^2.8",
         "twig/twig": ">=1.8,<2.0-dev"
@@ -17,5 +18,11 @@
     "config": {
         "preferred-install": "dist"
     },
-    "prefer-stable": true
+    "prefer-stable": true,
+
+    "autoload": {
+        "psr-4": {
+            "Bolt\\Docs\\": "./src/"
+        }
+    }
 }

--- a/console
+++ b/console
@@ -1,0 +1,9 @@
+#!/usr/bin/env php
+<?php
+require_once('vendor/autoload.php');
+
+$console = new Symfony\Component\Console\Application("Bolt Docs", "bolt-docs");
+$console->addCommands([
+    new Bolt\Docs\Command\BuildDocumentation()
+]);
+$console->run();

--- a/index.php
+++ b/index.php
@@ -29,6 +29,7 @@ if (empty($request) || $request == "v20" || $request == "bolt-docs" || $request 
 $yaml = new Parser();
 $versions = $yaml->parse(file_get_contents('versions.yml'));
 
+
 // Determine if we're on 'docs' or on 'manual'
 $hostname = $_SERVER['SERVER_NAME'];
 if (strpos($hostname, 'manual') !== false) {
@@ -36,9 +37,17 @@ if (strpos($hostname, 'manual') !== false) {
     $menufile = 'menu_manual.yml';
     $sitetitle = 'Bolt user manual';
 } else {
-    $sourcefolder = './source_docs/';
-    $menufile = 'menu_docs.yml';
-    $sitetitle = 'Bolt documentation';
+    if (in_array(ltrim($prefix, '/'), $versions)) {
+        $sourcefolder = './version'.$prefix.'/source_docs/';
+        $menufile = './version'.$prefix.'/menu_docs.yml';
+        $sitetitle = 'Bolt documentation';
+        $prefix = '';
+    } else {
+        $sourcefolder = './source_docs/';
+        $menufile = 'menu_docs.yml';
+        $sitetitle = 'Bolt documentation';
+    }
+
 }
 
 if (!file_exists($sourcefolder . $request . ".md")) {

--- a/index.php
+++ b/index.php
@@ -25,6 +25,10 @@ if (empty($request) || $request == "v20" || $request == "bolt-docs" || $request 
 	die();
 }
 
+// Setup the parser and read the versions
+$yaml = new Parser();
+$versions = $yaml->parse(file_get_contents('versions.yml'));
+
 // Determine if we're on 'docs' or on 'manual'
 $hostname = $_SERVER['SERVER_NAME'];
 if (strpos($hostname, 'manual') !== false) {
@@ -44,7 +48,6 @@ if (!file_exists($sourcefolder . $request . ".md")) {
 }
 
 
-$yaml = new Parser();
 
 $menu = $yaml->parse(file_get_contents($menufile));
 

--- a/src/Command/BuildDocumentation.php
+++ b/src/Command/BuildDocumentation.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Yaml\Dumper;
 
 /**
  * Class BuildDocumentation console command
@@ -16,6 +17,7 @@ class BuildDocumentation extends Command
 {
 
     public $rootdir = '/version/';
+    public $versions = 'versions.yml';
 
     protected function configure()
     {
@@ -27,7 +29,7 @@ class BuildDocumentation extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return int|null|void
+     * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -46,5 +48,13 @@ class BuildDocumentation extends Command
             }
             $output->writeln("<info>Branch $branch written to $directory$branch</info>");
         }
+
+        // Write the passed in versions to the yml file
+
+        $dumper = new Dumper();
+        $yaml = $dumper->dump($input->getArgument('branches'));
+        $path = getcwd() . '/' . $this->versions;
+        file_put_contents($path, $yaml);
+        $output->writeln("<info>Versions saved to $path</info>");
     }
 }

--- a/src/Command/BuildDocumentation.php
+++ b/src/Command/BuildDocumentation.php
@@ -37,7 +37,7 @@ class BuildDocumentation extends Command
         $directory = getcwd().$this->rootdir;
 
         foreach ($input->getArgument('branches') as $branch) {
-            $tree = shell_exec('git ls-tree '.$branch." ./source/");
+            $tree = shell_exec('git ls-tree '.$branch." ./source_docs/");
             $tree = array_filter(explode("\n", $tree));
             $filelist = array_map('str_getcsv', $tree, array_fill(0, count($tree), "\t"));
             foreach ($filelist as $source) {

--- a/src/Command/BuildDocumentation.php
+++ b/src/Command/BuildDocumentation.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bolt\Docs\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Class BuildDocumentation console command
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class BuildDocumentation extends Command
+{
+    protected function configure()
+    {
+        $this->setName("bolt:build-docs")
+            ->addArgument('branches', InputArgument::IS_ARRAY, ['master'])
+            ->setDescription("Builds documentation from an array of git branches");
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        print_r($input->getArgument('branches'));
+    }
+}

--- a/src/Command/BuildDocumentation.php
+++ b/src/Command/BuildDocumentation.php
@@ -46,6 +46,10 @@ class BuildDocumentation extends Command
                 @mkdir(dirname($directory.$branch.'/'.$file), 0755, true);
                 file_put_contents($directory.$branch.'/'.$file, $content);
             }
+
+            $menu = shell_exec('git show '.$branch.":menu_docs.yml");
+            file_put_contents($directory.$branch.'/menu_docs.yml', $menu);
+
             $output->writeln("<info>Branch $branch written to $directory$branch</info>");
         }
 


### PR DESCRIPTION
Console command `./console bolt:build-docs 2.2 master` creates version folder for each of the passed in branches and outputs the version content to `version/xxx/` 

It also outputs a `versions.yml` file to git allowed version prefixes to access via request, so in the above example `docs.bolt.cm/2.2/introduction` and `docs.bolt.cm/master/introduction`

The `versions.yml` could also be used to make a dynamic list of links too, perhaps for the bottom of the sidebar.