### PR TITLE
enable versioned search results

### DIFF
--- a/view/_master.twig
+++ b/view/_master.twig
@@ -121,7 +121,8 @@
     <script type="text/javascript"> docsearch({
         apiKey: '1b46aac18cdcead6090088f1994f7ea8',
         indexName: 'bolt',
-        inputSelector: '#algolia-search'
+        inputSelector: '#algolia-search',
+        facetFilter: ["version:{{ version }}"]
         });
     </script>
 </body>


### PR DESCRIPTION
Assuming the `version` variable in twig holds `master` or `release-2-2` depending on which version you are.