### PR TITLE
Fix references to error in case of non-existent template

### DIFF
--- a/docs/content/contenttypes-and-records.md
+++ b/docs/content/contenttypes-and-records.md
@@ -145,9 +145,9 @@ templates](content-in-templates).
 
 When you refresh the front page of the website, you should see four news items
 listed on the page. You can click the title to go to the news item on a separate
-page, but you'll get an error. In the contenttype we defined the template as
-`newsitem.twig`, but it doesn't exist. Create the file in the `theme/base-2014/`
-folder, and add the following HTML-code:
+page, but it will use the default `record.twig` template. In the contenttype we
+defined the template as `newsitem.twig`, but it doesn't exist. Create the file 
+in the `theme/base-2014/` folder, and add the following HTML-code:
 
 ```
 <!DOCTYPE html>


### PR DESCRIPTION
A non-existent template won't generate an error, it will just fall back to previous candidates.