### PR TITLE
Update bolt-internals.md Typo correction

### DIFF
--- a/docs/internals/bolt-internals.md
+++ b/docs/internals/bolt-internals.md
@@ -27,7 +27,7 @@ There are four files that contain the controller collections, located in
 As such, they are all in the `\Bolt\Controllers` namespace. They are 'set up'
 in `src/Application.php`.
 
-* `Backend` rotues are all pretty straightforward.
+* `Backend` routes are all pretty straightforward.
 * `Async.php` routes are used for 'ajaxy' requests, like the
 'latest activity' widget on the dashboard.
 * `Routing` is the actual Controller that parses the routes found in `routing.yml`

--- a/docs/internals/task-scheduler.md
+++ b/docs/internals/task-scheduler.md
@@ -59,7 +59,7 @@ The parameter passed to `--run` can be any of the following:
 Extending
 ---------
 
-Bolt's task scheduler can be interfaced in extensions by setting an listener. To
+Bolt's task scheduler can be interfaced in extensions by setting a listener. To
 create a listener you need to something similar in your extension:
 
 ```


### PR DESCRIPTION
Corrects typo: "rotues"  to "routes" and a character deleted