### PR TITLE
Fixed wrong call to findBy in findOneBy example

### DIFF
--- a/docs/storage/repositories.md
+++ b/docs/storage/repositories.md
@@ -104,7 +104,7 @@ This method works identically to the `findBy` method above but will return a sin
 
 ```
 $repo = $app['storage']->getRepository('users');
-$user = $repo->findBy(['username' => $postedUser, 'password'=> $passHash]);
+$user = $repo->findOneBy(['username' => $postedUser, 'password'=> $passHash]);
 ```
 
 


### PR DESCRIPTION
The example code for findOneBy was using findBy instead of, err… findOneBy.