### PR TITLE
"Proxy .htaccess" doesn't rewrite /bolt-public/...

### DIFF
--- a/docs/howto/troubleshooting-outside-webroot.md
+++ b/docs/howto/troubleshooting-outside-webroot.md
@@ -138,7 +138,7 @@ folder:
 RewriteEngine on
 RewriteCond %{HTTP_HOST} ^domain-name.com$ [NC,OR]
 RewriteCond %{HTTP_HOST} ^www.domain-name.com$
-RewriteCond %{REQUEST_URI} !public/
+RewriteCond %{REQUEST_URI} !^/?public/
 RewriteRule (.*) /public/$1 [L]
 ```
 


### PR DESCRIPTION
The `RewriteCond %{REQUEST_URI}` must include the leading slash on the `/public/` folder. If not, it will happily match urls to the standard `/bolt-public/` folder, and *not* do the needed rewrite.

The extra regex is apparently needed because Apache sometimes doesn't include the first slash in `REQUEST_URI`. More info here:
http://webmasters.stackexchange.com/questions/27118/when-is-the-leading-slash-needed-in-mod-rewrite-patterns