### PR TITLE
Fixed typo

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -25,7 +25,7 @@ are default settings, and Bolt should work out-of-the-box.
     - gd
     - gmp
     - json
-    - mb_string
+    - mbstring
     - opcache (optional)
     - posix
     - xml


### PR DESCRIPTION
Fixed typo. 'mb_string' should be 'mbstring'