### PR TITLE
Added note regarding Twig and config.yml namespaces

### DIFF
--- a/docs/configuration/introduction.md
+++ b/docs/configuration/introduction.md
@@ -98,3 +98,5 @@ after compilation the value of `{{ config.get('mycustomversion') }}` will match
 the value set on the main application container.
 
 Note that at this point only string values are supported.
+
+Also note that configs are namespaced. `{{ config.get('mycustomversion') }}` may not be nessessarily available in your Twig templates directly. For more information regarding this, please refer to the [Bolt Internals] (https://docs.bolt.cm/3.0/internals/bolt-internals#code-app-config-code) documentation. In this particular example, use `{{ config.get('general/mycustomversion') }}` to access the above varaible in your template.

--- a/docs/configuration/introduction.md
+++ b/docs/configuration/introduction.md
@@ -99,4 +99,4 @@ the value set on the main application container.
 
 Note that at this point only string values are supported.
 
-Also note that configs are namespaced. `{{ config.get('mycustomversion') }}` may not be nessessarily available in your Twig templates directly. For more information regarding this, please refer to the [Bolt Internals] (https://docs.bolt.cm/3.0/internals/bolt-internals#code-app-config-code) documentation. In this particular example, use `{{ config.get('general/mycustomversion') }}` to access the above varaible in your template.
+Also note that configs are namespaced. `{{ config.get('mycustomversion') }}` may not be necessarily available in your Twig templates directly. For more information regarding this, please refer to the [Bolt Internals] (https://docs.bolt.cm/3.0/internals/bolt-internals#code-app-config-code) documentation. In this particular example, use `{{ config.get('general/mycustomversion') }}` to access the above variable in your template.


### PR DESCRIPTION
Added an explanation where Twig may need to use the `general` namespace of the config if the user added the variable directly into `config.yml`.