### PR TITLE
app['paths'] :fire:

### DIFF
--- a/cheatsheet.yml
+++ b/cheatsheet.yml
@@ -503,7 +503,7 @@ debug:
 apppath:
     title: "The `paths` variable"
     shorttitle: "{{ paths }}"
-    prefix: "To see the current paths use `{{ dump(paths) }}` in a template. Use a specific path like this: `{{ paths.theme }}`. In PHP, these are available as `$this->app['paths']`."
+    prefix: "To see the current paths use `{{ dump(paths) }}` in a template. Use a specific path like this: `{{ paths.theme }}`."
     table:
         - ["Key", "Value"]
         - ["`app`", "`/app/`"]
@@ -533,7 +533,7 @@ apppath:
         - ["`themebasepath`", "`/[path]/theme`"]
         - ["`themepath`", "`/[path]/theme/base-2016`"]
         - ["`webpath`", "`/[path]/bolt`"]
-    links: { "app['paths'] in the docs": "internals/container-service-references#app-resources" }
+    links: { "app['resources'] in the docs": "internals/container-service-references#app-resources" }
 
 
 apprequest:

--- a/docs/internals/container-service-references.md
+++ b/docs/internals/container-service-references.md
@@ -75,7 +75,6 @@ File system paths available are:
     "themebasepath" => "/path/to/bolt/theme"
     "themepath" => "/path/to/bolt/theme/base-2016"
     "templatespath" => "/path/to/bolt/theme/base-2016"
-  ]
 ```
 
 URL paths available are:
@@ -94,7 +93,6 @@ URL paths available are:
     "currenturl" => "https://bolt.cm/page/about"
     "hosturl" => "https://bolt.cm"
     "rooturl" => "https://bolt.cm/"
-  ]
 ```
 
 ## $app['db']


### PR DESCRIPTION
Only for 3.0 since the cheatsheet is MIA i 2.2