### PR TITLE
Update custom-bootstrapping.md

### DIFF
--- a/docs/extensions/custom-bootstrapping.md
+++ b/docs/extensions/custom-bootstrapping.md
@@ -27,7 +27,7 @@ bootstrap file, by convention it is best to name this `.bolt.php` since that fil
 is looked for automatically by other Bolt components. For example:
 
 ```
-$app = require __DIR__ . '../.bolt.php';
+$app = require __DIR__ . '/../.bolt.php';
 if ($app === false) {
     return false;
 }


### PR DESCRIPTION
didn't found .bolt.php ...error message:

Warning: require(/www/htdocs/w00c0a5e/bolt/public../.bolt.php): failed to open stream: No such file or directory in /www/htdocs/w00c0a5e/bolt/public/index.php on line 12

Fatal error: require(): Failed opening required '/www/htdocs/w00c0a5e/bolt/public../.bolt.php' (include_path='.:/usr/share/php:..') in /www/htdocs/w00c0a5e/bolt/public/index.php on line 12