### PR TITLE
remove moved directories from default config

### DIFF
--- a/docs/installation/webserver/nginx.md
+++ b/docs/installation/webserver/nginx.md
@@ -71,11 +71,6 @@ server {
         deny all;
     }
 
-    # Block access to the app, cache & vendor directories
-    location ~ /(?:app|src|tests|vendor)/(.*)$ {
-        deny all;
-    }
-
     # Block access to certain JSON files
     location ~ /(?:bower|composer|jsdoc|package)\.json$ {
         deny all;


### PR DESCRIPTION
the mentioned directories are moved outside the webroot - so they only interfere with legitimate site content.