### PR TITLE
Update bootstrapping guide

### DIFF
--- a/docs/extensions/custom-bootstrapping.md
+++ b/docs/extensions/custom-bootstrapping.md
@@ -1,89 +1,169 @@
 ---
 title: Custom Bootstrapping
 ---
-Creating your own Bootstrap
-=============================
+Customising Bootstrapping
+=========================
 
-Whilst Bolt is designed to be simple for anyone to install, its core
-functionality is also modular and easy to configure for anyone who is
-comfortable making a few modifications to their bootstrap code.
+Whilst Bolt is designed to be simple for anyone to install, its core 
+functionality is also modular and easy to configure for developers who are
+comfortable making a few modifications to how Bolt is bootstrapped.
 
-By default Bolt ships with its own bootstrap file which is responsible for
-setting up and running a Bolt application. Most of the advanced configuration
-options are best attained by taking over this responsibility in your own
-application. In the root of your project you will see an `index.php` file that
-should look like this:
+There are two ways your Bolt application is used, via web requests and via the
+command line with `nut`. Because there are two entry points, bootstrapping is
+done in a common `bootstrap.php` file. 
 
-```
-$app = require dirname(__FILE__) . '/../vendor/bolt/bolt/app/web.php';
-if ($app === false) {
-    return false;
-}
-$app->run();
-```
+One of the important functions of the bootstrap file is to read a loader 
+configuration file in the root directory of your project. By customising this
+configuration file, you can modify things like paths, the application class to
+use, and other services used by the application. This file can be either 
+`.bolt.yml` or `.bolt.php`. 
 
-Ideally you would replace the path to bootstrap.php with a link to your own
-bootstrap file, by convention it is best to name this `.bolt.php` since that filename
-is looked for automatically by other Bolt components. For example:
-
-```
-$app = require __DIR__ . '/../.bolt.php';
-if ($app === false) {
-    return false;
-}
-$app->run();
-```
+By default, Bolt uses `.bolt.yml` because who doesn't love YAML? But, for more
+complex, or dynamic configuration options, you can use a PHP file instead, 
+`.bolt.php`.
 
 The basics of configuring a Bolt application
 --------------------------------------------
 
-The job of your custom bootstrap file is to provide a bootstrapped `$app`
-object that the `index.php` file will then run. The simplest possible bootstrap
-file will look like this, assuming that your bootstrap file is in the 
-project root one level down from your `index.php` file in `./public`:
+The minimal requirement of configuring Bolt's bootstrap is path configuration. 
 
+Bolt needs to know these paths before configuration files like `config.yml` are
+read, in order to know where to find them.
+
+A default Bolt install will have a `.bolt.yml` file that would look similar to:
+
+```yaml
+paths:
+    web: public
+    themebase: public/theme
+    files: public/files
+    view: public/bolt-public/view
 ```
-// .bolt.php
-$configuration = new Bolt\Configuration\Composer(__DIR__);
-$configuration->setPath("web", "public");
 
-$app = new Bolt\Application(array('resources'=>$configuration));
+The equivalent PHP file to the one above would look like:
 
-$app->initialize();
-$config = [
-    'application' => $app,
-    'resources' => null,
+```php
+<?php
+
+return [
+    'paths' => [
+        'web'       => 'public',
+        'themebase' => 'public/theme',
+        'files'     => 'public/files',
+        'view'      => 'public/bolt-public/view',
+    ]
+];
+```
+
+Custom Application Class
+------------------------
+
+The Application class can be changed here as well. This allows you to modify
+Bolt services or add your own.
+
+In YAML, you can give the class name and we will create it for you. We will
+still apply any path customization afterwards as well. 
+
+```yaml
+application: My\Application
+paths:
+    web: public
+    #...
+```
+
+In PHP, you can give the class name...
+
+```php
+<?php
+
+return [
+    'application' => My\Application::class,
+    'paths' => [
+        'web' => 'public'
+        //...
+    ]
+];
+```
+
+For even more flexibly you can create the application yourself, or pull it in
+from another bootstrap file you have. It’s important to note here that if you
+give us an application object we'll assume it is ready to go. This means you'll
+need to apply any path customizations yourself. See the next section for an 
+example.
+
+```php
+<?php
+
+// Create the application.
+$app = new My\Application();
+
+return [
+    'application' => $app
 ];
 
-return $config;
+// Alternatively, you can just return the pre-configured application object
+return $app;
 ```
 
-You can make any modifications you like to the `$app` variable within
-your bootstrap, or to keep things well organised you can register your
-own extensions or providers onto the app.
 
-All you need to ensure is that you return an array with an `application`
-key set to an instance of your Bolt app.
+Adding your own providers
+-------------------------
 
-Mounting Bolt on an existing Application
+If you don't want to extend Bolt\Application but still want to register your
+own services you can do that here. However, this can only be done with the PHP
+file version and you have to create the application yourself.
+
+This gives a lot of scope to extend and augment core functionality, since you
+can either replace any core Bolt service, or as is described in the Silex
+[TwigServiceProvider] documentation, you can extend any existing Bolt service
+and add additional configurations to the service object.
+
+```php
+<?php
+
+$resources = new Bolt\Configuration\Composer(__DIR__);
+$resources->setPath('web', 'public');
+
+$app = new Bolt\Application(['resources' => $resources]);
+
+$app->initialize();
+
+$app->register(new MyApp\Provider\ConsoleProvider());
+$app->register(new MyApp\Provider\ControllerProvider());
+$app->register(new MyApp\Provider\TwigProvider());
+
+return $app;
+```
+
+You can make modifications to the services in the `$app` variable within this
+scope, such as replacing an existing service, or [extend][] an existing one,
+providing you do not attempt to either use the service, or access the `Request`
+object/service.
+
+Mounting Bolt on an existing application
 ----------------------------------------
 
 A lot of work has been done on the internals of Bolt which allow it now to run
 as a self- contained `HTTPKernelInterface` application without interfering with
-any of the global namespace or constants. So if you use
-[StackPHP](http://stackphp.com/) (or similar) you can mount Bolt onto a url
-prefix as simply as this:
+any of the global namespace or constants. So if you use [StackPHP] (or similar)
+you can mount Bolt onto a URL prefix as simply as this:
 
-```
+```php
+// Assuming this is in public/index.php and Bolt is located in vendor/bolt/bolt/
 $map = [
-    "/another" => new AnotherApplication(),
-    "/blog" => new Bolt\Application(['resources'=>new Bolt\Configuration\Composer(__DIR__)])
+    '/another' => new AnotherApplication(),
+    '/blog'    => require __DIR__ . '/../vendor/bolt/bolt/app/bootstrap.php'
 ];
 $app = (new Stack\Builder())
     ->push('Stack\UrlMap', $map)
     ->resolve($app);
+
 Stack\run($app);
 ```
 
 This means that you can, for instance, use Bolt to manage one specific part of
 a larger application set.
+
+[StackPHP]: http://stackphp.com/
+[TwigServiceProvider]: http://silex.sensiolabs.org/doc/providers/twig.html#customization
+[extend]: https://github.com/silexphp/Pimple/tree/1.1#modifying-services-after-creation


### PR DESCRIPTION
This PR is aimed at superseding #490, and also finally documents the `application` parameter that can be used in the loader configuration file (`bolt.yml` or `bolt.php`).

We are trying to also point to a more modular approach to our loading/configuration that has been worked on heavily by the team collectively, and obviously there is still work to be done in core.

Something that this effort by @CarsonF and myself is about, is trying to make some initial steps in improving the communication to all, by those actually doing the initial core work.

What I hang my head in shame about right now, is that this supersedes @rossriley's work on #490, and he's probably the best of all of the back-end team members at documenting stuff, and he's put in a fair amount of effort, but only missed because the two people behind *this PR* didn't initially communicate well/at all their changes to core.