### PR TITLE
More detailed docs for templateselect field type

### DIFF
--- a/docs/fields/templateselect.md
+++ b/docs/fields/templateselect.md
@@ -29,7 +29,7 @@ render the record, but can still be used by the theme developer in the theme.
 
 The field has a few options to change the functionality of the field.
 
-* `filter` A pattern that decides which tempates to show. For example to only
+* `filter` A glob pattern that decides which tempates to show. For example to only
   match templates that start with the word pages you can do like this:
 
 ```


### PR DESCRIPTION
It took me some time to guess what "pattern" in docs really mean. By first I thought it is regular expression but unfortunately not. Second thought was some custom filtering mechanism and eventually I had to search in bolt source files to figure out it uses Symfony glob finder and that "filter" option is really a __glob pattern matching__.

I think it's reasonable to add this short additional word to save time for some poor souls freaking out while trying to specify a little bit more complex filtering rule.