### PR TITLE
Repeater field cleanup

### DIFF
--- a/docs/fields/repeater.md
+++ b/docs/fields/repeater.md
@@ -2,7 +2,7 @@
 title: Repeater
 ---
 Repeater
-=========
+========
 
 A special field type available as a field definition is the `repeater` field type which
 allows you to compose an array-like structure of sub-fields within a single field name.
@@ -12,7 +12,7 @@ allows you to compose an array-like structure of sub-fields within a single fiel
 The configuration of a repeating field set comprises the main field set name, along with
 the definition of the sub fields.
 
-```
+```yaml
         features:
             type: repeater
             fields:
@@ -42,7 +42,7 @@ all the sub-fields without necessarily knowing the field names.
 For instance if you just want to iterate over all sets and then all fields
 within the set then the template code will look like this:
 
-```
+```twig
 {% for feature in record.features %}
     {% for field in feature %}
         {{ field }}
@@ -60,7 +60,7 @@ field from the collection by name. For instance using the same example as above
 but knowing that our repeat set comprises the individual sub-fields
 `companyname`, `telephone` and `email` we can output the fields like this:
 
-```
+```twig
 {% for company in record.companies %}
     <h2>{{ company.get('companyname') }}</h2>
     <h4>Tel: {{ company.get('telephone') }}</h4>
@@ -78,7 +78,7 @@ The field has a one option to change the functionality of the field.
   omit this setting then an unlimited number of sets can be created. The
   configuration for that looks like this:
 
-```
+```yaml
         features:
             type: repeater
             limit: 3


### PR DESCRIPTION
Same as previous PR, just for the Repeater field which is only available in Bolt 3.0 and above.