### PR TITLE
Added information about Local Extension Helper.

### DIFF
--- a/docs/extensions/basics/creating.md
+++ b/docs/extensions/basics/creating.md
@@ -64,7 +64,12 @@ and `src/ExtensionNameExtension.php`.
   8. In the `extra` section of `composer.json` update `bolt-class` to reflect
      the new namespace and class name (from steps 1 & 2).
 
-If this is your first local extension, Bolt will automatically add an extension called `Local Extension Helper`. You will see the helper extension listed alongside your other extensions. If the helper extension is marked as `-[INVALID]` and `-[DISABLED]` you will need to go to the `extensions/` directory and run `composer update`.
+If this is your first local extension, Bolt will automatically add an extension called `Local Extension Helper`. You will see the helper extension listed alongside your other extensions. 
+
+If the helper extension is marked as `-[INVALID]` and `-[DISABLED]` you will need install it by **one** of the following methods:
+- Press the `Install all packages` button on the Extend admin page.
+- Go to the root folder of your Bolt installation and run `app/nut extensions:setup`.
+- Go to the `extensions/` directory and run `composer update`.
 
 The above steps will get you started, and below is some more in depth information about the configuration.
 

--- a/docs/extensions/basics/creating.md
+++ b/docs/extensions/basics/creating.md
@@ -64,8 +64,9 @@ and `src/ExtensionNameExtension.php`.
   8. In the `extra` section of `composer.json` update `bolt-class` to reflect
      the new namespace and class name (from steps 1 & 2).
 
-The above steps will get you started, and below is some more in depth information
-about the configuration.
+If this is your first local extension, Bolt will automatically add an extension called `Local Extension Helper`. You will see the helper extension listed alongside your other extensions. If the helper extension is marked as `-[INVALID]` and `-[DISABLED]` you will need to go to the `extensions/` directory and run `composer update`.
+
+The above steps will get you started, and below is some more in depth information about the configuration.
 
 **Extended starter extension**
 


### PR DESCRIPTION
I ran into a little bit of trouble following the create extension instructions, the files for Local Extension Helper were not being installed automatically.

The "Install all packages" button didn't install the helper files, is it meant to? I didn't reference the Install all packages button in my PR because I wasn't sure if that's what it was meant to do or not.