### PR TITLE
[RFC] Improving the 'version select dropdown'.

### DIFF
--- a/view/templates/_versionselect.twig
+++ b/view/templates/_versionselect.twig
@@ -1,0 +1,37 @@
+{% set numeric = [] %}
+{% set other = [] %}
+{% for k, v in versions %}
+    {% if k matches '/^[-+]?[0-9]*\\.?[0-9]+$/' %}
+        {% set numeric = numeric|merge([v]) %}
+    {% else %}
+        {% set other = other|merge([v]) %}
+    {% endif %}
+{% endfor %}
+
+<div id="version-changer" class="version-changer">
+    <form action="" method="get">
+        <select>
+            <option>Selected version: <strong>Bolt {{ version }}</strong></option>
+            <optgroup label=''>
+            <optgroup label='Switch to version:'>
+                {% for v in numeric if v matches '/^[-+]?[0-9]*\\.?[0-9]+$/' %}
+                    <option value="{{ path('page', {version: v}) }}">{{ v }}
+                        {% if v < default_version %}<em>(legacy)</em>{% endif %}
+                        {% if v == default_version %}(current stable){% endif %}
+                        {% if v > default_version %}(future release){% endif %}
+                    </option>
+                {% endfor %}
+            </optgroup>
+
+            {% if other is not empty %}
+            <optgroup label=''>
+            <optgroup label='Other:'>
+                {% for v in other %}
+                    <option value="{{ path('page', {version: v}) }}">{{ v }}</option>
+                {% endfor %}
+            </optgroup>
+            {% endif %}
+        </select>
+    </form>
+</div>
+

--- a/view/templates/_versionselect.twig
+++ b/view/templates/_versionselect.twig
@@ -14,7 +14,7 @@
             <option>Selected version: <strong>Bolt {{ version }}</strong></option>
             <optgroup label=''>
             <optgroup label='Switch to version:'>
-                {% for v in numeric if v matches '/^[-+]?[0-9]*\\.?[0-9]+$/' %}
+                {% for v in numeric|reverse %}
                     <option value="{{ path('page', {version: v}) }}" class="version-{{ v }}">{{ v }}
                         {% if v == default_version %}(current stable){% endif %}
                         {% if v > default_version %}(future release){% endif %}

--- a/view/templates/_versionselect.twig
+++ b/view/templates/_versionselect.twig
@@ -15,8 +15,7 @@
             <optgroup label=''>
             <optgroup label='Switch to version:'>
                 {% for v in numeric if v matches '/^[-+]?[0-9]*\\.?[0-9]+$/' %}
-                    <option value="{{ path('page', {version: v}) }}">{{ v }}
-                        {% if v < default_version %}<em>(legacy)</em>{% endif %}
+                    <option value="{{ path('page', {version: v}) }}" class="version-{{ v }}">{{ v }}
                         {% if v == default_version %}(current stable){% endif %}
                         {% if v > default_version %}(future release){% endif %}
                     </option>

--- a/view/templates/index.twig
+++ b/view/templates/index.twig
@@ -9,18 +9,7 @@
 
         <a href="#sidebar" class="button hide-for-large" id="jumpbutton">Jump to docs navigation</a>
 
-        <div id="version-changer" class="version-changer">
-            <form action="" method="get">
-                <select>
-                    <option>Current: <strong>{{ version }}</strong></option>
-                    <optgroup label='Switch to version:'>
-                    {% for v in versions if v != version %}
-                        <option value="{{ path('page', {version: v}) }}">{{ v }}</option>
-                    {% endfor %}
-                    </optgroup>
-                </select>
-            </form>
-        </div>
+        {% include '_versionselect.twig' %}
 
         {% if version != default_version %}
             <p class="note" style="margin-top: 1em;">


### PR DESCRIPTION
Before: 

![screen shot 2016-10-29 at 17 23 09](https://cloud.githubusercontent.com/assets/1833361/19830644/67a0c1c2-9dfc-11e6-966b-2753b28c0373.png)

After: 

![screen shot 2016-10-29 at 17 20 54](https://cloud.githubusercontent.com/assets/1833361/19830640/5455aa56-9dfc-11e6-948e-77e7ad04cc62.png)

 - The label makes more sense
 - You can see what is the current stable release, and which is "future release"
 - If the `var/versions/` folder contains non-numeric folders, list them at the bottom. 
