### PR TITLE
Fixed: Path order on live site in correct order.

### DIFF
--- a/src/Documentation.php
+++ b/src/Documentation.php
@@ -39,7 +39,7 @@ class Documentation
 
     public function load()
     {
-        $dirs = (new Finder())->directories()->in($this->versionDir)->depth(0);
+        $dirs = (new Finder())->directories()->in($this->versionDir)->sortByName()->depth(0);
 
         foreach ($dirs as $dir) {
             /** @var SplFileInfo $dir */


### PR DESCRIPTION
Make sure we get paths in the correct order, instead of something undefined