### PR TITLE
ContentType branding

### DIFF
--- a/docs/content/contenttypes-and-records.md
+++ b/docs/content/contenttypes-and-records.md
@@ -1,7 +1,7 @@
 ---
-title: Contenttypes and Records
+title: ContentTypes and Records
 ---
-Contenttypes and records
+ContentTypes and records
 ========================
 
 All content in Bolt is stored in the database in a logical and flexible
@@ -12,33 +12,33 @@ some sort of 'pages' for generic stuff like 'about us' or 'Company History'.
 Most websites will also have some form of news-like items, that are shown based
 on the date that they were published. Some other sites might have 'book
 reviews' or 'event dates' or even completely different content. All of these
-different types of content are called **Contenttypes** in Bolt, and you can add
+different types of content are called **ContentTypes** in Bolt, and you can add
 as many different contenttypes as you need.
 
 Each contenttype is defined by a couple of fixed, required **Fields** that are
 used internally, but otherwise you're free to define how the content in a
-Contenttype is structured. For instance, in an 'event', you'll need a date on
+ContentType is structured. For instance, in an 'event', you'll need a date on
 which the event takes place. For a 'book review', you'll need an author and
 publisher of the book. Other commonly used fields are `title`, `introduction`
 or maybe an `image`. Some of the Fields are fixed, which means that every
 contenttype has them. For example, every contenttype has a Field for `id`,
 `slug`, `datecreated` and `ownerid`. Below we'll describe how to define
-Contenttypes and Fields.
+ContentTypes and Fields.
 
-All content on your website is part of one specific Contenttype, which
+All content on your website is part of one specific ContentType, which
 automatically defines which fields that piece of content has, which in turn
 specifies how that piece of content is structured. Each one of those pieces of
 content is called a **Record**, and is stored in the database. For example, a
-single 'event' is a Record of Contenttype 'events' and a single 'page' is a
-Record of Contenttype 'pages'.
+single 'event' is a Record of ContentType 'events' and a single 'page' is a
+Record of ContentType 'pages'.
 
 When you're creating a page on a website that shows listings of several
 Records, you're using an **Array of Records**. For instance, if you create a
 page that has 'the five latest events', you'll be using an Array of 5 'event'
-Records of Contenttype 'events'.
+Records of ContentType 'events'.
 
 Before we'll dive into the details, we'll give you a quick example of a simple
-Contenttype, how it's stored, and how you can access it in templates to display
+ContentType, how it's stored, and how you can access it in templates to display
 on your site.
 
 An Example: News items
@@ -100,8 +100,8 @@ we defined in our `contenttypes.yml` file.
 
 When you go to Configuration > Check Database, the database will be updated,
 and you'll be given the option to add some "Lorem Ipsum" Records to the newly
-created Contenttype. If you do this, and go back to the dashboard, you'll see
-your new Contenttype with some example news items. Sweet!
+created ContentType. If you do this, and go back to the dashboard, you'll see
+your new ContentType with some example news items. Sweet!
 
 <a href="/files/content-example2.png" class="popup"><img src="/files/content-example2.png" width="500"></a>
 
@@ -192,8 +192,8 @@ Defining contenttypes
 
 The contenttypes in Bolt are defined in the file `app/config/contenttypes.yml`.
 You can edit this file directly, or from within the Bolt interface under
-Configuration > Contenttypes. Each distinct group of content can have its own
-Contenttype, to enable the user to store the content as needed. Fields can be
+Configuration > ContentTypes. Each distinct group of content can have its own
+ContentType, to enable the user to store the content as needed. Fields can be
 added later on, and settings can be changed, so nothing is set in stone.
 
 The general structure of each contenttype is:
@@ -228,16 +228,16 @@ The available options are:
 
 | Option | Description |
 |--------|-------------|
-| `name` | The name of the Contenttype, as it should be shown on screen or in the browser. It should be plural, if possible. |
-| `singular_name` | The name of one Record in the Contenttype. This should be singular. For example, if the Contenttype's name is 'Pages', this should be 'Page' |
+| `name` | The name of the ContentType, as it should be shown on screen or in the browser. It should be plural, if possible. |
+| `singular_name` | The name of one Record in the ContentType. This should be singular. For example, if the ContentType's name is 'Pages', this should be 'Page' |
 | `slug` (optional) | This determines the slug of the contenttype, and therefore the URLs that are generated for this contenttype. When omitted, the slug will be automatically generated. |
 | `singular_slug` (optional) | This determines the slug of a single record in this contenttype, and therefore the URLs that are generated for these records. When omitted, the slug will be automatically generated. |
 | `description` (optional) | A short description of the contenttype. This will be shown on the overview screen in the right aside column. |
 | `fields` | The fields that make up the content in this contenttype. See the [Fields Definition](#field-definitions) section below for details. |
 | `taxonomy` | An array listing the different taxonomies used by this contenttype. For example `[ categories, tags ]`. See the page on [Taxonomies](../content/taxonomies) for details. |
 | `relations` | An array listing the different relations available to this contenttype. See the page on [Relations](../content/relationships) for details. |
-| `record_template` | The default template to use, when displaying a single Record of this Contenttype. The template itself should be located in your `theme/foo/` folder, in Bolt's root folder. This can be overridden on a per-record basis, if one of the fields is defined as type `templateselect`. |
-| `listing_template` | The default template to use, when displaying an overview of Records of this Contenttype. The template itself should be located in your `theme/foo/` folder, in Bolt's root folder. |
+| `record_template` | The default template to use, when displaying a single Record of this ContentType. The template itself should be located in your `theme/foo/` folder, in Bolt's root folder. This can be overridden on a per-record basis, if one of the fields is defined as type `templateselect`. |
+| `listing_template` | The default template to use, when displaying an overview of Records of this ContentType. The template itself should be located in your `theme/foo/` folder, in Bolt's root folder. |
 | `listing_records` | The amount of records to show on a single overview page in the frontend. If there are more records, the results will be paginated   |
 | `listing_sort` | The field used to sort the results on. You can reverse the order by adding a '-'. For example `title` or `-datepublish`. |
 | `sort` (optional) | The default sorting of this contenttype, in the overview in Bolt's backend interface. For example `-datecreated`. |
@@ -246,7 +246,7 @@ The available options are:
 | `show_in_menu` (optional) | When set to `false` the contenttype will show in a submenu instead of as a top level menu. Can also be set to a word or sentence to group contenttypes under different menus. |
 | `default_status` (optional) | Use this to set the default status for new records in this contenttype, i.e. `published`, `held`, `draft` or `timed`. |
 | `searchable` (optional) | A boolean value to determine whether this contenttype should show up in search results. |
-| `viewless` (optional) | When set to `true`, routes will not be set for the Contenttype listing, or the records themselves. Useful for creating [resource contenttypes](../howto/resource-contenttype). |
+| `viewless` (optional) | When set to `true`, routes will not be set for the ContentType listing, or the records themselves. Useful for creating [resource contenttypes](../howto/resource-contenttype). |
 | `title_format` (optional) | Is used to determine the format of the title in the backend. For example if you have two fields for `firstname` and `lastname` you might put `[ firstname, lastname ]` here. |
 | `icon_many` (optional) | A [Font Awesome](http://fortawesome.github.io/Font-Awesome/) icon to be used in the sidebar for this contenttype. For example: `fa:cubes` |
 | `icon_one` (optional) | A [Font Awesome](http://fortawesome.github.io/Font-Awesome/) icon to be used in the sidebar for a single record of this contenttype. For example: `fa:cube`. |
@@ -263,7 +263,7 @@ At the topmost level, it contains the following items:
 
 | Item | Description |
 |------|-------------|
-| `id` | The unique identifying  number of this record in the database, for this Contenttype. Note: there are duplicate ids for records in different contenttypes. For example, there can be a record with id `1` for Pages, and also a record with id `1` for News. |
+| `id` | The unique identifying  number of this record in the database, for this ContentType. Note: there are duplicate ids for records in different contenttypes. For example, there can be a record with id `1` for Pages, and also a record with id `1` for News. |
 | `values` | `An array with the values of this record. |
 | `taxonomy` | `An array (or `NULL`) for the taxonomy of this record. |
 | `contenttype` | `An array representation of the contenttype that this record belongs to, complete with the fields that the record should have.  |
@@ -294,16 +294,16 @@ templates, see the [Template tags](../templates/templatetags) page.
 Advanced: YAML Repeated Nodes
 -----------------------------
 
-In order to make your Contenttype definitions more compact, and consistent, you
+In order to make your ContentType definitions more compact, and consistent, you
 can use YAML repeated nodes. Bolt has a special YAML key called `__nodes` that
-it will use only for repeated nodes, and not create a Contenttype or table for.
-These nodes then become selectable in a Contenttype definition.
+it will use only for repeated nodes, and not create a ContentType or table for.
+These nodes then become selectable in a ContentType definition.
 
 Each node is defined by an `key_name: &node_name` with the fields then included,
 and indented below.
 
 ```apache
-## Defaults nodes. Does not create a Contenttype
+## Defaults nodes. Does not create a ContentType
 __nodes:
     record_defaults: &record_defaults
         title:
@@ -332,7 +332,7 @@ In the above example, we have the `record_defaults` node that defines `title`
 and `slug` fields, a `content_defaults` node that defines the `image` and `body`
 fields, and a `template_defaults` node that defines our template selector.
 
-Using the above nodes we could simplify a default `Pages` Contenttype to look
+Using the above nodes we could simplify a default `Pages` ContentType to look
 like this:
 
 ```apache

--- a/docs/content/contenttypes-and-records.md
+++ b/docs/content/contenttypes-and-records.md
@@ -13,15 +13,15 @@ Most websites will also have some form of news-like items, that are shown based
 on the date that they were published. Some other sites might have 'book
 reviews' or 'event dates' or even completely different content. All of these
 different types of content are called **ContentTypes** in Bolt, and you can add
-as many different contenttypes as you need.
+as many different ContentTypes as you need.
 
-Each contenttype is defined by a couple of fixed, required **Fields** that are
+Each ContentType is defined by a couple of fixed, required **Fields** that are
 used internally, but otherwise you're free to define how the content in a
 ContentType is structured. For instance, in an 'event', you'll need a date on
 which the event takes place. For a 'book review', you'll need an author and
 publisher of the book. Other commonly used fields are `title`, `introduction`
 or maybe an `image`. Some of the Fields are fixed, which means that every
-contenttype has them. For example, every contenttype has a Field for `id`,
+ContentType has them. For example, every ContentType has a Field for `id`,
 `slug`, `datecreated` and `ownerid`. Below we'll describe how to define
 ContentTypes and Fields.
 
@@ -44,7 +44,7 @@ on your site.
 An Example: News items
 ----------------------
 
-In this example, we'll create a very simple contenttype for news items. Each
+In this example, we'll create a very simple ContentType for news items. Each
 news item will have a title, an image, and some text. We'll also be using some
 of the fixed Fields, like the `slug`, the `ownerid` and the various dates.
 
@@ -56,7 +56,7 @@ Bolt is run, the <code>.yml.dist</code>-files will be automatically copied to
 you first run Bolt, just copy <code>contenttypes.yml.dist</code> to
 <code>contenttypes.yml</code> yourself.</p>
 
-To add this contenttype, edit the file `app/config/contenttypes.yml`, and add
+To add this ContentType, edit the file `app/config/contenttypes.yml`, and add
 the following to the bottom or top of the file:
 
 ```apache
@@ -82,14 +82,14 @@ news:
 means that the indentation is important. Make sure you leave leading spaces
 intact.</p>
 
-This creates a new contenttype 'news'. Its name is 'News', and a single record
+This creates a new ContentType 'news'. Its name is 'News', and a single record
 is named 'Newsitem'. We've defined fields for 'title', 'slug', 'image' and
 'text'. The 'record_template' defines the default template to use, when displaying a
 single record in the browser.
 
 After you've saved the file and Refresh the Dashboard screen in your browser,
 you'll be greeted by a warning that the Database needs to be updated. If we do
-this, the new contenttype will be added to the database, with the fields that
+this, the new ContentType will be added to the database, with the fields that
 we defined in our `contenttypes.yml` file.
 
 <p class="tip"><strong>Tip:</strong> The Bolt backend is located at
@@ -138,7 +138,7 @@ templates](content-in-templates).
 
 When you refresh the front page of the website, you should see four news items
 listed on the page. You can click the title to go to the news item on a separate
-page, but you'll get an error. In the contenttype we defined the template as
+page, but you'll get an error. In the ContentType we defined the template as
 `newsitem.twig`, but it doesn't exist. Create the file in the `theme/base-2014/`
 folder, and add the following HTML-code:
 
@@ -187,16 +187,16 @@ your record or array.
 
 This is explained in detail in the section [The structure of a Record](#structure-record).
 
-Defining contenttypes
+Defining ContentTypes
 ---------------------
 
-The contenttypes in Bolt are defined in the file `app/config/contenttypes.yml`.
+The ContentTypes in Bolt are defined in the file `app/config/contenttypes.yml`.
 You can edit this file directly, or from within the Bolt interface under
 Configuration > ContentTypes. Each distinct group of content can have its own
 ContentType, to enable the user to store the content as needed. Fields can be
 added later on, and settings can be changed, so nothing is set in stone.
 
-The general structure of each contenttype is:
+The general structure of each ContentType is:
 
 ```apache
 name:
@@ -206,7 +206,7 @@ name:
     ..
 ```
 
-The `name` defines the name of the contenttype, and it should be a 'safe'
+The `name` defines the name of the ContentType, and it should be a 'safe'
 version of the `name:` option below. Basically this means that it should be a
 lowercase version, without any special characters. Like this:
 
@@ -230,26 +230,26 @@ The available options are:
 |--------|-------------|
 | `name` | The name of the ContentType, as it should be shown on screen or in the browser. It should be plural, if possible. |
 | `singular_name` | The name of one Record in the ContentType. This should be singular. For example, if the ContentType's name is 'Pages', this should be 'Page' |
-| `slug` (optional) | This determines the slug of the contenttype, and therefore the URLs that are generated for this contenttype. When omitted, the slug will be automatically generated. |
-| `singular_slug` (optional) | This determines the slug of a single record in this contenttype, and therefore the URLs that are generated for these records. When omitted, the slug will be automatically generated. |
-| `description` (optional) | A short description of the contenttype. This will be shown on the overview screen in the right aside column. |
-| `fields` | The fields that make up the content in this contenttype. See the [Fields Definition](#field-definitions) section below for details. |
-| `taxonomy` | An array listing the different taxonomies used by this contenttype. For example `[ categories, tags ]`. See the page on [Taxonomies](../content/taxonomies) for details. |
-| `relations` | An array listing the different relations available to this contenttype. See the page on [Relations](../content/relationships) for details. |
+| `slug` (optional) | This determines the slug of the ContentType, and therefore the URLs that are generated for this ContentType. When omitted, the slug will be automatically generated. |
+| `singular_slug` (optional) | This determines the slug of a single record in this ContentType, and therefore the URLs that are generated for these records. When omitted, the slug will be automatically generated. |
+| `description` (optional) | A short description of the ContentType. This will be shown on the overview screen in the right aside column. |
+| `fields` | The fields that make up the content in this ContentType. See the [Fields Definition](#field-definitions) section below for details. |
+| `taxonomy` | An array listing the different taxonomies used by this ContentType. For example `[ categories, tags ]`. See the page on [Taxonomies](../content/taxonomies) for details. |
+| `relations` | An array listing the different relations available to this ContentType. See the page on [Relations](../content/relationships) for details. |
 | `record_template` | The default template to use, when displaying a single Record of this ContentType. The template itself should be located in your `theme/foo/` folder, in Bolt's root folder. This can be overridden on a per-record basis, if one of the fields is defined as type `templateselect`. |
 | `listing_template` | The default template to use, when displaying an overview of Records of this ContentType. The template itself should be located in your `theme/foo/` folder, in Bolt's root folder. |
 | `listing_records` | The amount of records to show on a single overview page in the frontend. If there are more records, the results will be paginated   |
 | `listing_sort` | The field used to sort the results on. You can reverse the order by adding a '-'. For example `title` or `-datepublish`. |
-| `sort` (optional) | The default sorting of this contenttype, in the overview in Bolt's backend interface. For example `-datecreated`. |
+| `sort` (optional) | The default sorting of this ContentType, in the overview in Bolt's backend interface. For example `-datecreated`. |
 | `recordsperpage` (optional) | The amount of records shown on each page in the Bolt backend. If there are more records, they will be paginated. |
-| `show_on_dashboard` (optional) | When set to `false` the contenttype will not appear in the 'Recently edited &hellip;' list on the dashboard page. |
-| `show_in_menu` (optional) | When set to `false` the contenttype will show in a submenu instead of as a top level menu. Can also be set to a word or sentence to group contenttypes under different menus. |
-| `default_status` (optional) | Use this to set the default status for new records in this contenttype, i.e. `published`, `held`, `draft` or `timed`. |
-| `searchable` (optional) | A boolean value to determine whether this contenttype should show up in search results. |
-| `viewless` (optional) | When set to `true`, routes will not be set for the ContentType listing, or the records themselves. Useful for creating [resource contenttypes](../howto/resource-contenttype). |
+| `show_on_dashboard` (optional) | When set to `false` the ContentType will not appear in the 'Recently edited &hellip;' list on the dashboard page. |
+| `show_in_menu` (optional) | When set to `false` the ContentType will show in a submenu instead of as a top level menu. Can also be set to a word or sentence to group ContentTypes under different menus. |
+| `default_status` (optional) | Use this to set the default status for new records in this ContentType, i.e. `published`, `held`, `draft` or `timed`. |
+| `searchable` (optional) | A boolean value to determine whether this ContentType should show up in search results. |
+| `viewless` (optional) | When set to `true`, routes will not be set for the ContentType listing, or the records themselves. Useful for creating [Resource ContentTypes](../howto/resource-contenttype). |
 | `title_format` (optional) | Is used to determine the format of the title in the backend. For example if you have two fields for `firstname` and `lastname` you might put `[ firstname, lastname ]` here. |
-| `icon_many` (optional) | A [Font Awesome](http://fortawesome.github.io/Font-Awesome/) icon to be used in the sidebar for this contenttype. For example: `fa:cubes` |
-| `icon_one` (optional) | A [Font Awesome](http://fortawesome.github.io/Font-Awesome/) icon to be used in the sidebar for a single record of this contenttype. For example: `fa:cube`. |
+| `icon_many` (optional) | A [Font Awesome](http://fortawesome.github.io/Font-Awesome/) icon to be used in the sidebar for this ContentType. For example: `fa:cubes` |
+| `icon_one` (optional) | A [Font Awesome](http://fortawesome.github.io/Font-Awesome/) icon to be used in the sidebar for a single record of this ContentType. For example: `fa:cube`. |
 
 The structure of a Record
 -------------------------
@@ -263,13 +263,13 @@ At the topmost level, it contains the following items:
 
 | Item | Description |
 |------|-------------|
-| `id` | The unique identifying  number of this record in the database, for this ContentType. Note: there are duplicate ids for records in different contenttypes. For example, there can be a record with id `1` for Pages, and also a record with id `1` for News. |
+| `id` | The unique identifying  number of this record in the database, for this ContentType. Note: there are duplicate ids for records in different ContentTypes. For example, there can be a record with id `1` for Pages, and also a record with id `1` for News. |
 | `values` | `An array with the values of this record. |
 | `taxonomy` | `An array (or `NULL`) for the taxonomy of this record. |
-| `contenttype` | `An array representation of the contenttype that this record belongs to, complete with the fields that the record should have.  |
+| `contenttype` | `An array representation of the ContentType that this record belongs to, complete with the fields that the record should have.  |
 | `user` | `an array, containing information about the user, like the displayname, email-address, etcetera. |
 
-The values contain the fields that are defined in the contenttype, together
+The values contain the fields that are defined in the ContentType, together
 with a few other fixed fields. The fixed fields are:
 
 | Field name | Description |

--- a/docs/content/permissions.md
+++ b/docs/content/permissions.md
@@ -70,7 +70,7 @@ URL route in the Bolt back-end, e.g. the `global:translation` permission maps
 to `http://your-domain.org/bolt/translation`. The default configuration file
 describes those permissions in more detail that do not follow this mapping.
 
-**Per-Contenttype permissions** govern actions specific to a contenttype. They
+**Per-ContentType permissions** govern actions specific to a contenttype. They
 are defined in three "layers": the `contenttype-all`, `contenttype-default`,
 and `contenttypes` sections. The way these work is a bit tricky to wrap one's
 head around, but it allows for maximum flexibility without too much clutter.
@@ -85,7 +85,7 @@ For each contenttype, the following permissions are available:
 | `publish` and `depublish` | required to change the publication state of a record |
 | `change-ownership` | required to transfer ownership of a record to another user |
 
-How Contenttype Specific Permissions Are Calculated
+How ContentType Specific Permissions Are Calculated
 ----------------------------------------------------
 For contenttype related actions, permissions can be set individually for each
 contenttype. For this, we define three groups of permission sets.

--- a/docs/extensions/essentials.md
+++ b/docs/extensions/essentials.md
@@ -324,7 +324,7 @@ As you might know, Bolt has two 'sandboxed' Twig environments, to prevent
 possible security exploits in the templates. This is to prevent having a
 careless developer or implementor allow a user to insert Twig tags where they
 should not. If you want your extension's Twig function to be available inside a
-contenttype's record field, you will need to explicitly add an `isSafe()`
+ContentType's record field, you will need to explicitly add an `isSafe()`
 function to your `Extension.php` file, that simply returns `true`:
 
 ```
@@ -334,7 +334,7 @@ public function isSafe()
 }
 ```
 
-Note: You will _also_ need to set `allowtwig` to `true`, in your contenttype
+Note: You will _also_ need to set `allowtwig` to `true`, in your ContentType
 definition. If either one of them isn't set, the twig tag will not work inside
 the content. This way you have maximum control over where it works, and where it
 doesn't. See also 'Field Definitions' in the page '[ContentTypes and Records][ct+r]'.
@@ -414,14 +414,14 @@ function foo()
 Overriding the default 'Content' class
 --------------------------------------
 
-ContentTypes can specify the class to be used for records of that contenttype.
-This is useful for when you have a specific contenttype, and you would like to
-provide extra functionality to that single contenttype.
+ContentTypes can specify the class to be used for records of that ContentType.
+This is useful for when you have a specific ContentType, and you would like to
+provide extra functionality to that single ContentType.
 
 An extension can then define that class, overriding / extending the default
 behaviour of `\Bolt\Content`.
 
-For example, in your contenttype, use:
+For example, in your ContentType, use:
 ```YAML
 entries:
     name: Entries

--- a/docs/extensions/essentials.md
+++ b/docs/extensions/essentials.md
@@ -337,7 +337,7 @@ public function isSafe()
 Note: You will _also_ need to set `allowtwig` to `true`, in your contenttype
 definition. If either one of them isn't set, the twig tag will not work inside
 the content. This way you have maximum control over where it works, and where it
-doesn't. See also 'Field Definitions' in the page '[Contenttypes and Records][ct+r]'.
+doesn't. See also 'Field Definitions' in the page '[ContentTypes and Records][ct+r]'.
 
 Adding storage events
 ---------------------
@@ -414,7 +414,7 @@ function foo()
 Overriding the default 'Content' class
 --------------------------------------
 
-Contenttypes can specify the class to be used for records of that contenttype.
+ContentTypes can specify the class to be used for records of that contenttype.
 This is useful for when you have a specific contenttype, and you would like to
 provide extra functionality to that single contenttype.
 

--- a/docs/fields/common.md
+++ b/docs/fields/common.md
@@ -26,7 +26,7 @@ in more detail below.
 ### Grouping fields in tabs
 
 
-If you have a number of fields in your contenttype, it might be convenient to
+If you have a number of fields in your ContentType, it might be convenient to
 add grouping to the fields, by using tabs. It will look like this:
 
 <a href="/files/contenttype-tabs.png" class="popup"><img src="/files/contenttype-tabs.png"></a>
@@ -94,7 +94,7 @@ description will override that field type default.
 
 When you want to give a record a default value, use `default:`. For most fields
 this will set the initial value of the field, when you're creating a new record
-of this contenttype. For `date` and `datetime` fields, the value is passed
+of this ContentType. For `date` and `datetime` fields, the value is passed
 through [strtotime](http://php.net/manual/en/function.strtotime.php), meaning
 that you can use a fixed date as default, like "1900-01-01 12:00:00", but also
 relative dates like "first day of this month", "next Monday" or "yesterday".

--- a/docs/fields/select.md
+++ b/docs/fields/select.md
@@ -7,7 +7,7 @@ Select
 ### Choose from Preset values:
 
 A drop-down list to make a pre-defined selection from. This fields has many
-options and many possibilties but is less complicated than it might seem at
+options and many possibilities but is less complicated than it might seem at
 first glance.
 
 ### Basic Configuration:
@@ -24,9 +24,9 @@ first glance.
 {{ record.somevalue }}
 ```
 
-### Populating the values from a contenttype
+### Populating the values from a ContentType
 
-You can also get the values from the records of a contenttype.
+You can also get the values from the records of a ContentType.
 
 ```yaml
         somevalue:
@@ -44,7 +44,7 @@ For example to display both the id and title of 'pages':
             values: pages/id,title
 ```
 
-If you wish to store another field or value from the original contenttype in
+If you wish to store another field or value from the original ContentType in
 your database, use the keys setting. If you do this, it will not store the
 'id', but the value of the field you specify. For example:
 
@@ -79,7 +79,7 @@ Finally you can pass filters to the query using the filter option. For a full
 reference of what can be passed to a where filter you can see the content
 fetching documentation.
 
-As well as filters on the contenttype values you can also pass in taxonomy
+As well as filters on the ContentType values you can also pass in taxonomy
 conditions too, as in the example below.
 
 ```yaml

--- a/docs/getting-started/about.md
+++ b/docs/getting-started/about.md
@@ -30,9 +30,9 @@ Building a website with Bolt: we assume you have the usual Frontender skills.
 You know HTML/CSS, and have working knowledge about JavaScript so you can
 implement things like Google Analytics trackers, jQuery plugins and such. To
 create a working site out of your static HTML, you'll need to know about how
-Bolt uses Content and Contenttypes, and how to make templates using Twig.
+Bolt uses Content and ContentTypes, and how to make templates using Twig.
 Information about those topics can be found in the chapters
-[Contenttypes and Records](../content/contenttypes-and-records) and
+[ContentTypes and Records](../content/contenttypes-and-records) and
 [Building templates](../templates/building-templates).
 
 With creating Bolt we wanted to focus on creating something simple,

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -167,7 +167,7 @@ files use the same `.yml` syntax, and can also be edited via the Bolt backend.
 | File | Description |
 |------|-------------|
 | `app/config/config.yml` | The file where all general configuration of your website is defined. |
-| `app/config/contenttypes.yml` | The definitions of your contenttypes, e.g.  pages, blog items etc.
+| `app/config/contenttypes.yml` | The definitions of your ContentTypes, e.g.  pages, blog items etc.
 | `app/config/menu.yml` | The file that contains the menu(s) for your website.
 | `app/config/taxonomy.yml` | Categories, chapters, tags etc. are defined here. |
 | `app/config/routing.yml` | The file where you can define custom urls for your website.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -7,7 +7,7 @@ Introduction
 This is the Bolt Documentation. There are a lot of docs for Bolt, so it is split
 up in a few sections. If you're getting started with Bolt or looking for
 installation instructions, start with the first part. The second part of the
-docs is about working _in_ Bolt. Setting up contenttypes, taxonomies, etc. The
+docs is about working _in_ Bolt. Setting up ContentTypes, taxonomies, etc. The
 third part is a reference for all things related to building your templates and
 themes for Bolt. If you're just beginning with Bolt, don't forget to check out
 our excellent Bolt Theming Tutorial as well.

--- a/docs/howto/building-multilingual-websites.md
+++ b/docs/howto/building-multilingual-websites.md
@@ -25,7 +25,7 @@ information.</p>
 Table of Contents
 -----------------
 
- * [Defining Contenttypes](#defining-contenttypes)
+ * [Defining ContentTypes](#defining-contenttypes)
  * [Defining Routes](#defining-routes)
  * [Defining Menus](#defining-menus)
  * [Making Templates and Fetching Content](#making-templates-and-fetching-content)
@@ -41,7 +41,7 @@ Table of Contents
    * [Pagination on Search Results Pages](#pagination-search-results-pages)
 
 
-Defining Contenttypes
+Defining ContentTypes
 ---------------------
 
 An important step when making websites, is to properly [define your contenttypes

--- a/docs/howto/resource-contenttype.md
+++ b/docs/howto/resource-contenttype.md
@@ -1,20 +1,20 @@
 ---
-title: Making a 'resource' Contenttype
+title: Making a 'resource' ContentType
 ---
-Making a 'resource' Contenttype
+Making a 'resource' ContentType
 ===============================
 
-A common question that comes up is how to create a generic Contenttype for
+A common question that comes up is how to create a generic ContentType for
 things like 404 pages and site header text that can be used in templates. A
-simple approach is to create a '*resource*' Contenttype.
+simple approach is to create a '*resource*' ContentType.
 
 For the purposes of this HOWTO we care going to call it "resource". But as with
-any Contenttype, you can use any unique name.
+any ContentType, you can use any unique name.
 
-Creating the Contenttype
+Creating the ContentType
 ------------------------
 
-Firstly, in your `contenttypes.yml` file create a new Contenttype with the
+Firstly, in your `contenttypes.yml` file create a new ContentType with the
 following parameters:
 
 ```yaml
@@ -83,12 +83,12 @@ confined.
 
 ### Searchable
 
-By setting `searchable: false` these Contenttype records will be excluded from
+By setting `searchable: false` these ContentType records will be excluded from
 search results.
 
 ### Viewless
 
-By setting `viewless: true`, routes will not be set for the Contenttype listing,
+By setting `viewless: true`, routes will not be set for the ContentType listing,
 or the records themselves.
 
 Permissions

--- a/docs/howto/sortingorder-in-contenttypes.md
+++ b/docs/howto/sortingorder-in-contenttypes.md
@@ -1,14 +1,14 @@
 ---
-title: Sorting a contenttype with a 'sortorder'
+title: Sorting a ContentType with a 'sortorder'
 ---
-Sorting a contenttype with a 'sortorder'
+Sorting a ContentType with a 'sortorder'
 ========================================
 
-Sometimes you might need to sort Pages or some other contenttype on an
+Sometimes you might need to sort Pages or some other ContentType on an
 arbitrary order, instead of on "Title, aphabetically" or "Date added". In these
 cases, you can use the built-in taxonomy that can use a given sortorder. This
 will allow you to manually define the order of all records in that specific
-contenttype. To set it up, follow these two steps:
+ContentType. To set it up, follow these two steps:
 
 First, make sure you have a taxonomy set up to use the 'sortorder' sorting.
 Make sure it has set both `behaves_like: grouping` as well as `has_sortorder:
@@ -28,11 +28,11 @@ Tip: You will _need_ to keep the `options:` setting in there. Even if you don't
 really need to order the records into different groups, you'll need to keep at
 least one of the 'options' present in your taxonomy.
 
-Secondly, you'll want to make sure that you configure your contenttype to use
-this taxonomy in your `contenttypes.yml`. Note that the contenttype does _not_
+Secondly, you'll want to make sure that you configure your ContentType to use
+this taxonomy in your `ContentTypes.yml`. Note that the ContentType does _not_
 require a `sort:` option. In this case Bolt will use the sorting, as defined in
 our taxonomy, so defining another sort option would make no sense. For example,
-see this `pages` contenttype:
+see this `pages` ContentType:
 
 ```
 pages:

--- a/docs/internals/the-model.md
+++ b/docs/internals/the-model.md
@@ -16,7 +16,7 @@ the user to go to the 'repair database' screen.
 
 Even though Bolt strives to be as simple as possible, it makes sense to think of
 Bolt as an [MVC application][mvc]. Silex provides the Controller part, the Twig
-templates are the View and the Contenttypes define the Model part.
+templates are the View and the ContentTypes define the Model part.
 
 All access to the content and the contentypes is done through the Storage class.
 Records of content have a Content class. Browse the files `src/Storage.php`

--- a/docs/manual/contenttypes.md
+++ b/docs/manual/contenttypes.md
@@ -1,7 +1,7 @@
 ---
-title: Contenttypes
+title: ContentTypes
 ---
-Contenttypes
+ContentTypes
 ==================
 
 Your contenttypes

--- a/docs/templates/templates-routes.md
+++ b/docs/templates/templates-routes.md
@@ -125,7 +125,7 @@ example:
 ```
 
 
-#### Contenttype overrides
+#### ContentType overrides
 
 This case overrides the default routing for contenttype **page**. Bolt will no
 longer create `/page/{slug}` links but will now create `/{slug}` routes. The old


### PR DESCRIPTION
Replace "contenttype" & "Contenttype" with "ContentType"

This was orignally targetted by @SahAssar at 3.0 … but moving it backwards now for easier merges