### PR TITLE
Added a line showing how to access the taxonomy slug

### DIFF
--- a/docs/contenttypes/taxonomies.md
+++ b/docs/contenttypes/taxonomies.md
@@ -177,6 +177,8 @@ something like this:
 {% endif %}
 ```
 
+If you're using a listing, and would like to access the taxonomy name, simply use `{{ slug }}`.
+
 Displaying all used taxonomies
 ------------------------------
 


### PR DESCRIPTION
Will need applying to `release/3.1` and `release/3.2`.