### PR TITLE
Fix extending global twig environment

### DIFF
--- a/docs/extensions/intermediate/service-providers.md
+++ b/docs/extensions/intermediate/service-providers.md
@@ -61,14 +61,14 @@ templates, you can use the following:
 ```php
     public function registerServices(Application $app)
     {
-        $app['twig'] = $app->extend(
+        $app['twig'] = $app->share($app->extend(
             'twig',
             function ($twig) use ($app) {
                 $config = $this->getConfig();
                 $twig->addGlobal('extensionsetting_foo', $config['foo']);
                 return $twig;
             }
-        );
+        ));
     }
 ```
 


### PR DESCRIPTION
When extending the global twig environment, it should be wrapped around $app->share() so it won't get called each time the service is consumed.