### PR TITLE
Set correct names for composer .dist files

### DIFF
--- a/docs/installation/install-command-line.md
+++ b/docs/installation/install-command-line.md
@@ -38,8 +38,8 @@ to this:
 ├── public/
 ├── vendor/
 ├── README.md
-├── composer.json
-└── composer.lock
+├── composer.json.dist
+└── composer.lock.dist
 ```
 
 These are the folders that contain all of the Bolt code, resources and other


### PR DESCRIPTION
To avoid any confusion, since after the installation you only have the .dist files