### PR TITLE
Some fixes and cleanup

### DIFF
--- a/docs/fields/geolocation.md
+++ b/docs/fields/geolocation.md
@@ -26,7 +26,9 @@ To insert a simple map from Google with a marker at the given location, use:
 <img src="http://maps.googleapis.com/maps/api/staticmap?center={{ record.location.latitude }},{{ record.location.longitude }}&zoom=14&size=617x300&sensor=false&markers={{ record.location.latitude }},{{ record.location.longitude }}">
 ```
 
-More info about these static maps, can be found at [Static Maps API V2 Developer Guide][1].
-Of course, you can use the geolocations with any mapping service you like, since
-latitude and longitude is a common geographic coordinate system used by many
-services.
+More info about these static maps, can be found in the [Static Maps API V2
+Developer Guide][1]. Of course, you can use the geolocation with any mapping
+service you like, since latitude and longitude is a common geographic coordinate
+system used by many services.
+
+[1]: https://developers.google.com/maps/documentation/static-maps/

--- a/docs/fields/hidden.md
+++ b/docs/fields/hidden.md
@@ -4,8 +4,8 @@ title: Hidden field
 Hidden field
 ============
 
-The hidden field is like the text field, 
-except the difference that it's being hidden from the content editor.
+The hidden field is like the text field, except it's hidden from the content
+editor.
 
 ### Basic Configuration:
 

--- a/docs/fields/imagelist.md
+++ b/docs/fields/imagelist.md
@@ -27,7 +27,7 @@ images:
 
 ### Options:
 
-The field has a one option to change the functionality of the field:
+The field has one option to change the functionality of the field:
 
 * `extensions` Allows you to restrict users to only be able to upload files with
   certain file extensions.

--- a/docs/fields/repeater.md
+++ b/docs/fields/repeater.md
@@ -95,11 +95,11 @@ contenttype with a `sections` repeater, acces them like this:
 
 ### Options
 
-The field has a one option to change the functionality of the field.
+The field has one option:
 
-* `limit`: Define a limit to how many sets an editor is able to create. If you
-  omit this setting then an unlimited number of sets can be created. The
-  configuration for that looks like this:
+* `limit`: Limit how many sets an editor is able to create. If you omit this
+  setting, then an unlimited number of sets can be created. The configuration
+  for that option looks like this:
 
 ```yaml
         features:

--- a/docs/fields/select.md
+++ b/docs/fields/select.md
@@ -6,7 +6,7 @@ Select field
 
 ### Choose from Preset values:
 
-A drop-down list to make a pre-defined selection from. This fields has many
+A drop-down list to make a pre-defined selection from. This field has many
 options and many possibilities but is less complicated than it might seem at
 first glance.
 
@@ -79,8 +79,8 @@ Finally you can pass filters to the query using the filter option. For a full
 reference of what can be passed to a where filter you can see the content
 fetching documentation.
 
-As well as filters on the ContentType values you can also pass in taxonomy
-conditions too, as in the example below.
+In adition to filters on the ContentType values, you can use taxonomy
+conditions, as in the following example:
 
 ```yaml
         somevalue:
@@ -125,7 +125,7 @@ Or if you want to print out the selected values in an `ul`:
 ```twig
 <ul>
     {% for values in record.somevalues %}
-        <li>{{ values }}
+        <li>{{ values }}</li>
     {% endfor %}
 </ul>
 ```
@@ -139,10 +139,13 @@ Or if you just want to print them out after one another separated by commas:
 
 ### Defining values as a hash
 
-The list with options can be defined as either a 'map' or a 'hash'. If you use
-a list (like above), the same values will be stored in the database as they are
-shown in the pull-down selector that the editor sees. If you want to store
-another value than is shown, you can use a so-called 'hash'. For example:
+The options in the list can be defined as either a 'map' or a 'hash'. If you use
+a list (like above), the options visible in the drop-down list will be the
+values stored in the database. If you want to store other values, you can use a
+so-called 'hash'.
+
+In the following example, 'yes', 'no' and 'undecided' will be stored in the
+database:
 
 ```yaml
         somevalue:


### PR DESCRIPTION
I read [your previous comment](https://github.com/bolt/docs/pull/631#issuecomment-274316752) about versions 3.0 and 3.2, but I started some commits in 3.2 already, I don’t have much time these days, and I believe you’ll be faster to rebase properly based on your knowledge of the workflow. Sorry to add some work.

- `example below` and `following example`. This is about not assuming where some content will visually be, but where it will sit in the flow of the text: If the documentation is printed, for example, then some content at the top of next page is not below, but always following or preceding.
- I simplified a few sentences; sometimes removing text that I found redundant. I prefer simple sentences, so let me know if that was too much. :)
- Use identical naming for `drop-down list`.
- Add “missing” closing tag in HTML example.
- Add missing URL to Geolocation field documentation.