### PR TITLE
Update updating.md (add link to permissions story in update instructions)

### DIFF
--- a/docs/upgrading/updating.md
+++ b/docs/upgrading/updating.md
@@ -12,7 +12,13 @@ As with all web-based applications, it's good practice to keep your site up to
 date with the latest version. Bolt is built in such a way, that none of the
 files that are used for the configuration are included in the distribution
 files. In practice, this means that upgrading Bolt works almost the same way
-as installing a new copy of bolt. Skip to the right section below:
+as installing a new copy of bolt. 
+
+If you run into issues after installing, you may have to 
+[repeat setting the permissions](/installation/permissions#setting-permissions-quick-amp-easy)
+on some directories.
+
+Skip to the right section below:
 
 Updating on the command line
 ----------------------------


### PR DESCRIPTION
Related an issue I had twice after updating from 3.1 to 3.2 with /app/cache/production not having the correct permissions.
https://boltcms.slack.com/archives/general/p1486394131011459 

Not sure if this deserves a `p class="note"` - too many notes might become chaotic.