### PR TITLE
Local extension migration guide

### DIFF
--- a/docs/extensions/bundled/activation.md
+++ b/docs/extensions/bundled/activation.md
@@ -1,0 +1,43 @@
+---
+title: Activation
+level: advanced
+---
+Activation
+==========
+
+Once your Bundle can be autoloaded, then one more step is needed to enable Bolt
+to load them.
+
+To active a Bundle, you need to add an `extensions` key to either your
+`.bolt.yml` or `.bolt.php` file in the root of your project, with the values
+being the Bundles you want Bolt to load.
+
+
+Updating `.bolt.yml` or `.bolt.php`
+-----------------------------------
+
+An example using `.bolt.yml`:
+
+```yaml
+extensions:
+    - BundleBaseNamespace\MyBundleExtension
+```
+
+To clarify, the value you put in the yml file is exactly what you would use to
+instantiate the class, so in code the above is equivalent to
+`new \BundleBaseNamespace\MyBundleExtension()`
+
+An example using `.bolt.php`
+
+```php
+<?php
+
+use BundleBaseNamespace\MyBundleExtension;
+
+return [
+    'extensions' => [
+        new MyBundleExtension()
+    ]
+];
+```
+

--- a/docs/extensions/bundled/autoloading.md
+++ b/docs/extensions/bundled/autoloading.md
@@ -1,0 +1,61 @@
+---
+title: Autoloading
+level: advanced
+---
+Autoloading
+===========
+
+### Initial Check
+
+If you've installed Bolt via Composer, you will already have two files in your
+site's root directory, `composer.json` and `composer.lock`. If those two files
+exist, you can continue to the next section.
+
+However, if you've installed via an archive file, you should have in your root
+directory the files `composer.json.dist` and `composer.lock.dist`. Each of
+these now needs to be renamed, minus the `.dist` extension.
+
+```bash
+$ cp composer.json.dist composer.json
+$ cp composer.lock.dist composer.lock
+```
+
+
+### Updating `composer.json` autoload
+
+You need to make one entry for each of your bundled extensions in your root
+`composer.json` file, e.g.:
+
+```json
+    "autoload" : {
+        "psr-4" : {
+            "bolt/bolt": "^%%VERSION%%",
+            "BundleBaseNamespace\\": "src/BundleBaseNamespace",
+            "Acme\\OtherBundleBaseNamespace\\": "extensions/acme/frozbot/OtherBundleBaseNamespace"
+        }
+    }
+```
+
+The setup here is identical to how you would setup your own application. You
+may well decide to move extensions to be part of your main Application
+namespace, and location:
+
+
+### Updating the autoloader
+
+After updating the `autoload` section of your `composer.json` file, you will
+need to update the project's autoloader.
+
+First thing you will need, if you don't have it already, is a recent version of
+Composer. To get this, see the [Composer Download][composer] page for
+instructions.
+
+Secondly, from the project's roots directory, run Composer with the
+`dump-autoload` argument, e.g.:
+
+
+```bash
+$ composer dump-autoload
+```
+
+[composer]: https://getcomposer.org/download/

--- a/docs/extensions/bundled/file-location.md
+++ b/docs/extensions/bundled/file-location.md
@@ -1,0 +1,41 @@
+---
+title: File Location & Layout
+level: advanced
+---
+File Location & Layout
+======================
+
+As Bundles are just a part of your site project's code, their location is
+relative to your site's root directory is flexible, and your decision on
+location should be influenced by the necessary file type(s).
+
+
+### Choosing a location
+
+#### PHP only
+
+If your Bundle contains only PHP file(s), and Twig and web assets are kept with
+the site's theme, we recommend using the base namespace of your Bundle as a
+sub-directory of `{site root}/src`,
+
+For example, if your Bundle namespace was `Acme\BundleBaseNamespace`:
+
+```
+{site root}/src/BundleBaseNamespace
+```
+
+
+#### PHP with resources
+
+If you want you Bundle to include non-PHP files, you're better off putting the
+contents into a sub-directory of `extension/` with the pattern
+`extension/{bundle name}`, for example:
+
+| Directory  | Description                                                    |
+| ---------- | -------------------------------------------------------------- |
+| `extension/{bundle name}/src`       | Extension's PHP code
+| `extension/{bundle name}/config`    | Configuration base files (`config.yml.dist`)
+| `extension/{bundle name}/templates` | Twig templates. These should be kept separate from public assets
+
+
+

--- a/docs/extensions/bundled/index.md
+++ b/docs/extensions/bundled/index.md
@@ -1,0 +1,10 @@
+---
+title: Bundled Extensions
+short_title: Bundled Extensions
+redirect: extensions/bundled/introduction
+pages:
+    - introduction
+    - file-location
+    - autoloading
+    - activation
+---

--- a/docs/extensions/bundled/introduction.md
+++ b/docs/extensions/bundled/introduction.md
@@ -1,0 +1,122 @@
+---
+title: Introduction
+level: advanced
+---
+Introduction
+============
+
+Bundled extensions, or "Bundles", should be thought of as _components_ that are
+_specific_ to **your site project(s)**. As such, developed, managed, and
+deployed using the same tools and methodologies you would deploy your Bolt site
+would normally.
+
+Writing a Bundle has a lot in common with writing a regular extension, such as
+you'd find, and install, from the [Market Place][market]. In that, as simple as
+creating a class in your Application that implements
+`Bolt\Extension\ExtensionInterface`.
+
+However, it is very important to note that, Bundles **do not**:
+  * Manage updating of web included web assets with public directories
+  * Require a `composer.json` file
+  * Auto-configure autoloading
+
+<p class="note"><strong>Note:</strong> Bundles are, by design, intended
+as a collection of <strong>site-specific</strong>, functionality
+enhancing PHP code. File types such as Twig templates, CSS, and
+JavaScript, are better suited being located inside your site's theme
+directory.</p>
+
+
+### Getting Started
+
+The initial design & build of a Bundle has the following aspects that we
+highlight below:
+  * [Bundle files location & layout](#bundle-files-location-amp-layout)
+  * [Bundle loader class design](#bundle-loader-class-design)
+  * [Bundle namespace](#bundle-namespace)
+  * [Building the Bundle](#building-the-bundle)
+  * [Autoloading configuration](#autoloading-configuration)
+  * [Activation configuration](#activation-configuration)
+
+
+#### Bundle namespace
+
+Bundles need to defined inside their own base namespace. This namespace
+is important to decide on first, as it will influence the target
+directory location of your Bundle, and is needed for your _autoloading_,
+and _activation_ configuration
+
+<p class="note"><strong>Note:</strong> The last name in the namespace
+path internally serves as the "author" name.</p>
+
+
+#### Bundle files location & layout
+
+Bundles should be thought of as part of your site project's code, and as such
+their location relative to your site's root directory is flexible.
+
+The choice of location should be considered carefully, and according to both
+your project and Bundle's design requirements.
+
+For further reading, see the [Bundle file location][file-location] section.
+
+
+#### Bundle loader class design
+
+Your first architectural decision is the type of _extension loader_ class you
+are going to use to define and load your Bundle.
+
+You can chose to write your class, in order of difficulty, as:
+  * Simplicity — Just extend `\Bolt\Extension\SimpleExtension` and your class
+    loader will have immediate access to a "quick build" loader class
+  * Lightweight — Extend `\Bolt\Extension\AbstractExtension` for an
+    implementation of the `ExtensionInterface`
+  * Full control — Build your own complete implementation of
+    `\Bolt\Extension\ExtensionInterface`
+
+<p class="note"><strong>Note:</strong> The Bundle's loader class name,
+minus any "Extension" suffix, internally serves as the Bundle name.</p>
+
+
+#### Building the Bundle
+
+With a few minor exceptions, the [Basics][extensions-basics],
+[Intermediate][extensions-intermediate], and
+[Advanced][extensions-advanced] sections on writing extensions are a
+good reference point.
+
+
+#### Autoloading configuration
+
+[Autoloading section][autoloading]
+
+
+#### Activation configuration
+
+Once you have a bundled extension loaded in your application, the interface
+within the Bolt extensions screen has also been adjusted to separate bundled
+extensions from those installed via the Market Place.
+
+Your bundled extensions will now appear underneath the other installed
+extensions.
+
+[Activation section][activation]
+
+
+Difference to Market Place Extensions
+-------------------------------------
+
+<p class="note"><strong>Note:</strong> One big difference between bundled and
+normal extensions, is that bundled extensions <strong>do not</strong> require
+their own <code>composer.json</code> file.</p>
+
+Bundled extensions are completely self-managed in terms of configuration,
+automatic set-up of CSS & JavaScript assets in public locations, etc.
+
+[file-location]: bundled/file-location
+[autoloading]: bundled/autoloading
+[activation]: bundled/activation
+[extensions-basics]: ../basics/basics
+[extensions-intermediate]: ../basics/intermediate
+[extensions-advanced]: ../basics/advanced
+[market]: https://market.bolt.cm/

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -9,4 +9,5 @@ pages:
     - advanced
     - storage
     - custom-bootstrapping
+    - bundled
 ---

--- a/docs/upgrading/index.md
+++ b/docs/upgrading/index.md
@@ -6,4 +6,5 @@ pages:
     - moving-22-30
     - moving-22-30-basic
     - moving-22-30-advanced
+    - migrating-local-extensions-33
 ---

--- a/docs/upgrading/migrating-local-extensions-33.md
+++ b/docs/upgrading/migrating-local-extensions-33.md
@@ -4,42 +4,45 @@ title: "Migrating Local Extensions for Bolt 3.3"
 Migrating Local Extensions for Bolt 3.3
 ===========================================
 
-Bolt 3.3 brings with it a fairly big refactor of local extensions and unavoidably
-this will mean some breaking changes.
+Bolt 3.3 brings with it a fairly big refactor of local extensions and
+unavoidably this will mean some breaking changes.
 
 The good news is that by changing the approach a little we will hopefully make
 it a lot easier to write and add local extensions to your applications.
 
-#### The Essential Migration Steps
+## The Essential Migration Steps
 
-##### Autoloading
-Local extensions are not autoloaded within the extensions directory any more
-so you will need to add each local extensions directory to the root `composer.json`
-file.
+### Autoloading
 
-As an example, if you currently have a local extension at: `extensions/local/myname/myextension`
-your extension class may either be in that directory, or perhaps inside a `src` directory.
+Local extensions are not autoloaded within the extensions directory anymore so
+you will need to add each local extensions directory to the `composer.json`
+file in `extensions/`.
+
+As an example, if you currently have a local extension at:
+`extensions/local/myname/myextension` your extension class may either be in that
+directory, or perhaps inside a `src` directory.
 
 Let's assume the class is in the root directory, you need to open your root composer.json
 file and add this to the autoload/psr-4 section.
 
-    "Bolt\\Extension\\Myname\\MyExtensionNamespace\\": "extensions/local/myname/myextension"
+    "Bolt\\Extension\\Myname\\MyExtensionNamespace\\": "local/myname/myextension"
     
-If you don't currently have a psr-4 section in your composer.json file, then add it
-so it looks something like this
+If you don't currently have a psr-4 section in your `extensions/composer.json` file, then
+add it so it looks something like this
 
 ```json
     "autoload" : {
         "psr-4" : {
-            "Bolt\\Extension\\Myname\\MyExtensionNamespace\\": "extensions/local/myname/myextension"
+            "Bolt\\Extension\\Myname\\MyExtensionNamespace\\": "local/myname/myextension"
         }
     }
 ```
 
-You need to make one entry for each of your local extensions, the setup here is identical to how you
-would setup your own application and there's absolutely no need to keep your extensions inside `extensions/local`
-any more. You may well decide to move extensions to be part of your main App namespace and if so
-you can do something like the following...
+You need to make one entry for each of your local extensions. The setup here is
+identical to how you would setup your own application and there's absolutely no
+need to keep your extensions inside `extensions/local` any more. You may well
+decide to move extensions to be part of your main App namespace and if so you
+can do something like the following: 
 
 ```json
     "autoload" : {
@@ -49,14 +52,17 @@ you can do something like the following...
     }
 ```
 
-With the above setup you can move local extensions to `src/Extension/` and access the class via
-`new MyCompany\MyApp\Extension\SuperCoolExtension()`
+With the above setup you can move local extensions to `src/Extension/` and
+access the class via `new MyCompany\MyApp\Extension\SuperCoolExtension()`
 
-##### Activation
-Once your extensions can be autoloaded then one more step is needed to direct Bolt to load them.
+### Activation
 
-If you have a `.bolt.yml` file at the root of your project you can define which extension classes
-are loaded within that file. If you open the file as it is now then it will look something like this:
+Once your extensions can be autoloaded then one more step is needed to direct
+Bolt to load them.
+
+If you have a `.bolt.yml` file at the root of your project you can define which
+extension classes are loaded within that file. If you open the file as it is now
+then it will look something like this:
 
 ```yaml
 
@@ -67,9 +73,10 @@ paths:
     view: public/bolt-public/view
 ```
 
-You will need to edit that file to list which extensions are loaded, note that it is the main 
-extension class that needs to be specified. Assuming the autoload setup discussed in the last
-section your new `.bolt.yml` will now look like:
+You will need to edit that file to list which extensions are loaded, note that
+it is the main  extension class that needs to be specified. Assuming the
+autoload setup discussed in the last section your new `.bolt.yml` will now look
+like:
 
 ```yaml
 
@@ -78,14 +85,17 @@ paths:
     themebase: public/theme
     files: public/files
     view: public/bolt-public/view
+
 extensions:
     - Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass
 ```
 
-To clarify, the value you put in the yml file is exactly what you would use to instantiate the 
-class, so in code the above is equivalent to `new Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass()`
+To clarify, the value you put in the yml file is exactly what you would use to
+instantiate the  class, so in code the above is equivalent to 
+`new Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass()`
 
-If you used the other autoload structure discussed your file would look like this:
+If you used the other autoload structure discussed, your file would look like
+this:
 
 ```yaml
 paths:
@@ -93,34 +103,36 @@ paths:
     themebase: public/theme
     files: public/files
     view: public/bolt-public/view
+
 extensions:
     - MyCompany\MyApp\Extension\SuperCoolExtension
 ```
 
-If you use a php file to bootstrap your Bolt application then you will also need to add each
-extension using php code. Your bootstrap file is at `.bolt.php` and it currently probably looks
-like this:
+If you use a php file to bootstrap your Bolt application then you will also need
+to add each extension using php code. Your bootstrap file is at `.bolt.php` and
+it currently probably looks like this:
 
 ```php
 $configuration = new MyApp\Configuration(__DIR__);
 $app = new Bolt\Application(array('resources'=>$configuration));
-// Any other application setup carries on here.....
+// Any other application setup carries on here…
 
 // Adding your extension to Bolt
-$app['extensions']->add(new Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass();
+$app['extensions']->add(new Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass());
 
 $app->initialize();
 
 return $app;
 ```
 
-#### Other Information
+## Other Information
 
-As you may have realised, the `composer.json` files are now no longer needed for local extensions
-writing a Bolt extension is as simple as creating a class in your Application that implements
- `Bolt\Extension\ExtensionInterface` and adding the Fully Qualified Class Name to your `.bolt.yml`
-file.
+As you may have realised, the `composer.json` files are now no longer needed for
+local extensions writing a Bolt extension is as simple as creating a class in
+your Application that implements  `Bolt\Extension\ExtensionInterface` and adding
+the Fully Qualified Class Name to your `.bolt.yml` file.
 
-Once you have a local extension loaded in your application, the interface within the Bolt extensions
-screen has also been adjusted to separate local extensions from those installed via the Market Place.
-These local extensions will now appear underneath the other installed extensions.
+Once you have a local extension loaded in your application, the interface within
+the Bolt extensions screen has also been adjusted to separate local extensions
+from those installed via the Market Place. These local extensions will now
+appear underneath the other installed extensions.

--- a/docs/upgrading/migrating-local-extensions-33.md
+++ b/docs/upgrading/migrating-local-extensions-33.md
@@ -120,3 +120,7 @@ As you may have realised, the `composer.json` files are now no longer needed for
 writing a Bolt extension is as simple as creating a class in your Application that implements
  `Bolt\Extension\ExtensionInterface` and adding the Fully Qualified Class Name to your `.bolt.yml`
 file.
+
+Once you have a local extension loaded in your application, the interface within the Bolt extensions
+screen has also been adjusted to separate local extensions from those installed via the Market Place.
+These local extensions will now appear underneath the other installed extensions.

--- a/docs/upgrading/migrating-local-extensions-33.md
+++ b/docs/upgrading/migrating-local-extensions-33.md
@@ -1,0 +1,122 @@
+---
+title: "Migrating Local Extensions for Bolt 3.3"
+---
+Migrating Local Extensions for Bolt 3.3
+===========================================
+
+Bolt 3.3 brings with it a fairly big refactor of local extensions and unavoidably
+this will mean some breaking changes.
+
+The good news is that by changing the approach a little we will hopefully make
+it a lot easier to write and add local extensions to your applications.
+
+#### The Essential Migration Steps
+
+##### Autoloading
+Local extensions are not autoloaded within the extensions directory any more
+so you will need to add each local extensions directory to the root `composer.json`
+file.
+
+As an example, if you currently have a local extension at: `extensions/local/myname/myextension`
+your extension class may either be in that directory, or perhaps inside a `src` directory.
+
+Let's assume the class is in the root directory, you need to open your root composer.json
+file and add this to the autoload/psr-4 section.
+
+    "Bolt\\Extension\\Myname\\MyExtensionNamespace\\": "extensions/local/myname/myextension"
+    
+If you don't currently have a psr-4 section in your composer.json file, then add it
+so it looks something like this
+
+```json
+    "autoload" : {
+        "psr-4" : {
+            "Bolt\\Extension\\Myname\\MyExtensionNamespace\\": "extensions/local/myname/myextension"
+        }
+    }
+```
+
+You need to make one entry for each of your local extensions, the setup here is identical to how you
+would setup your own application and there's absolutely no need to keep your extensions inside `extensions/local`
+any more. You may well decide to move extensions to be part of your main App namespace and if so
+you can do something like the following...
+
+```json
+    "autoload" : {
+        "psr-4" : {
+            "MyCompany\\MyApp\\": "src"
+        }
+    }
+```
+
+With the above setup you can move local extensions to `src/Extension/` and access the class via
+`new MyCompany\MyApp\Extension\SuperCoolExtension()`
+
+##### Activation
+Once your extensions can be autoloaded then one more step is needed to direct Bolt to load them.
+
+If you have a `.bolt.yml` file at the root of your project you can define which extension classes
+are loaded within that file. If you open the file as it is now then it will look something like this:
+
+```yaml
+
+paths:
+    web: public
+    themebase: public/theme
+    files: public/files
+    view: public/bolt-public/view
+```
+
+You will need to edit that file to list which extensions are loaded, note that it is the main 
+extension class that needs to be specified. Assuming the autoload setup discussed in the last
+section your new `.bolt.yml` will now look like:
+
+```yaml
+
+paths:
+    web: public
+    themebase: public/theme
+    files: public/files
+    view: public/bolt-public/view
+extensions:
+    - Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass
+```
+
+To clarify, the value you put in the yml file is exactly what you would use to instantiate the 
+class, so in code the above is equivalent to `new Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass()`
+
+If you used the other autoload structure discussed your file would look like this:
+
+```yaml
+paths:
+    web: public
+    themebase: public/theme
+    files: public/files
+    view: public/bolt-public/view
+extensions:
+    - MyCompany\MyApp\Extension\SuperCoolExtension
+```
+
+If you use a php file to bootstrap your Bolt application then you will also need to add each
+extension using php code. Your bootstrap file is at `.bolt.php` and it currently probably looks
+like this:
+
+```php
+$configuration = new MyApp\Configuration(__DIR__);
+$app = new Bolt\Application(array('resources'=>$configuration));
+// Any other application setup carries on here.....
+
+// Adding your extension to Bolt
+$app['extensions']->add(new Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass();
+
+$app->initialize();
+
+return $app;
+```
+
+#### Other Information
+
+As you may have realised, the `composer.json` files are now no longer needed for local extensions
+writing a Bolt extension is as simple as creating a class in your Application that implements
+ `Bolt\Extension\ExtensionInterface` and adding the Fully Qualified Class Name to your `.bolt.yml`
+file.

--- a/docs/upgrading/migrating-local-extensions-33.md
+++ b/docs/upgrading/migrating-local-extensions-33.md
@@ -1,138 +1,88 @@
 ---
-title: "Migrating Local Extensions for Bolt 3.3"
+title: "Migrating Local Extensions to Bundles for Bolt 3.3"
 ---
-Migrating Local Extensions for Bolt 3.3
-===========================================
+Migrating Local Extensions to Bundles for Bolt 3.3
+==================================================
 
-Bolt 3.3 brings with it a fairly big refactor of local extensions and
-unavoidably this will mean some breaking changes.
+Bolt 3.3 brings with it the removal of "local extensions", and its replacement
+with Bundles.
+
+Unavoidably this will mean some breaking changes!
 
 The good news is that by changing the approach a little we will hopefully make
-it a lot easier to write and add local extensions to your applications.
+it a lot easier to write and add Bundles to your applications.
+
+## About Bundles
+
+Before moving on with this guide, it is a good idea to have a read of the
+documentation [section on Bundles][bundles].
+
 
 ## The Essential Migration Steps
 
+### Update Extension Environment
+
+If you've had local extensions installed, the extension `composer.json`
+and autoloader need to be updated.
+
+There are two ways to achieve this, first via Nut.
+
+```bash
+php ./app/nut extensions:setup
+```
+
+Alternatively you can visit the _Extensions_ page on your site's backend, and
+in the right side panel under _Maintenance_, expand the _"Run all Update"_
+drop down, select _"Rebuild Autoloader"_.
+
+
 ### Autoloading
 
-Local extensions are not autoloaded within the extensions directory anymore so
-you will need to add each local extensions directory to the `composer.json`
-file in `extensions/`.
+Bundles, unlike old-style local extensions, autoloading configuration is not
+handled _auto-magically_ by the Extensions Manager.
 
-As an example, if you currently have a local extension at:
-`extensions/local/myname/myextension` your extension class may either be in that
-directory, or perhaps inside a `src` directory.
+As a result, you will need to add each Bundle's directory to `composer.json`
+in site's root directory. You need to open your root `composer.json` file and
+add each Bundle's entry to the  to the `"psr-4"` sub-section of the
+`"autoload"` section.
 
-Let's assume the class is in the root directory, you need to open your root composer.json
-file and add this to the autoload/psr-4 section.
+For example, if you currently have a local extension, `myname/myextension`,
+located at `extensions/local/myname/myextension`, with your loader class inside
+a `src` directory, and `Bolt\Extension\Myname\MyExtensionNamespace` as the
+namespace.
 
-    "Bolt\\Extension\\Myname\\MyExtensionNamespace\\": "local/myname/myextension"
-    
-If you don't currently have a psr-4 section in your `extensions/composer.json` file, then
-add it so it looks something like this
 
 ```json
     "autoload" : {
         "psr-4" : {
-            "Bolt\\Extension\\Myname\\MyExtensionNamespace\\": "local/myname/myextension"
+            "bolt/bolt": "^%%VERSION%%",
+            "Bolt\\Extension\\Myname\\MyExtensionNamespace\\": "extensions/local/myname/myextension"
         }
     }
 ```
 
-You need to make one entry for each of your local extensions. The setup here is
-identical to how you would setup your own application and there's absolutely no
-need to keep your extensions inside `extensions/local` any more. You may well
-decide to move extensions to be part of your main App namespace and if so you
-can do something like the following: 
 
-```json
-    "autoload" : {
-        "psr-4" : {
-            "MyCompany\\MyApp\\": "src"
-        }
-    }
-```
+For further information see the section of the Bundles documentation on
+[configuring autoloading][autoloading].
 
-With the above setup you can move local extensions to `src/Extension/` and
-access the class via `new MyCompany\MyApp\Extension\SuperCoolExtension()`
+<p class="note"><strong>Note:</strong> You must always remember to run
+<code>composer dump-autoloader</code> in your site's root directory after
+making any changes to the <code>"autoload"</code> section of your site's
+<code>composer.json</code>.</p>
+
 
 ### Activation
 
 Once your extensions can be autoloaded then one more step is needed to direct
 Bolt to load them.
 
-If you have a `.bolt.yml` file at the root of your project you can define which
-extension classes are loaded within that file. If you open the file as it is now
-then it will look something like this:
+Activating your Bundles so they will be loaded is now handled via either your
+`.bolt.yml` or `.bolt.php` file.
 
-```yaml
+For further information see the section of the Bundles documentation on
+[configuring activation][activation].
 
-paths:
-    web: public
-    themebase: public/theme
-    files: public/files
-    view: public/bolt-public/view
-```
 
-You will need to edit that file to list which extensions are loaded, note that
-it is the main  extension class that needs to be specified. Assuming the
-autoload setup discussed in the last section your new `.bolt.yml` will now look
-like:
-
-```yaml
-
-paths:
-    web: public
-    themebase: public/theme
-    files: public/files
-    view: public/bolt-public/view
-
-extensions:
-    - Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass
-```
-
-To clarify, the value you put in the yml file is exactly what you would use to
-instantiate the  class, so in code the above is equivalent to 
-`new Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass()`
-
-If you used the other autoload structure discussed, your file would look like
-this:
-
-```yaml
-paths:
-    web: public
-    themebase: public/theme
-    files: public/files
-    view: public/bolt-public/view
-
-extensions:
-    - MyCompany\MyApp\Extension\SuperCoolExtension
-```
-
-If you use a php file to bootstrap your Bolt application then you will also need
-to add each extension using php code. Your bootstrap file is at `.bolt.php` and
-it currently probably looks like this:
-
-```php
-$configuration = new MyApp\Configuration(__DIR__);
-$app = new Bolt\Application(array('resources'=>$configuration));
-// Any other application setup carries on here…
-
-// Adding your extension to Bolt
-$app['extensions']->add(new Bolt\Extension\Myname\MyExtensionNamespace\ExtensionClass());
-
-$app->initialize();
-
-return $app;
-```
-
-## Other Information
-
-As you may have realised, the `composer.json` files are now no longer needed for
-local extensions writing a Bolt extension is as simple as creating a class in
-your Application that implements  `Bolt\Extension\ExtensionInterface` and adding
-the Fully Qualified Class Name to your `.bolt.yml` file.
-
-Once you have a local extension loaded in your application, the interface within
-the Bolt extensions screen has also been adjusted to separate local extensions
-from those installed via the Market Place. These local extensions will now
-appear underneath the other installed extensions.
+[bundles]: ../extensions/bundled
+[autoloading]: ../extensions/bundled/autoloading
+[activation]: ../extensions/bundled/activation


### PR DESCRIPTION
This upgrade guide should cover the move of local extensions during the upgrade to 3.3.

There's one bit still to cover which is the asset sync, but we need to have a further discussion on what strategy we are going to recommend for this.