### PR TITLE
Example code gave error in strict variables mode

### DIFF
--- a/docs/configuration/menus.md
+++ b/docs/configuration/menus.md
@@ -27,6 +27,7 @@ main:
         path: entry/2
       - label: Sub 2
         class: menu-item-class
+        path: entry/3
 ```
 
 In this case `main` is the name of the menu. The options are:


### PR DESCRIPTION
In the submenu, one of the items had no path or link. This results in an error in the default (base 2016) bolt menu twig.