### PR TITLE
Remove requirement on (optional) gmp PHP extension

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -24,7 +24,6 @@ are default settings, and Bolt should work out-of-the-box.
     - openssl
     - curl
     - gd
-    - gmp
     - json
     - mbstring
     - opcache (optional)


### PR DESCRIPTION
It is (optionally) used by `ircmaxell/security-lib` and `PasswordLib/PasswordLib`, but neither package require it

Related: https://github.com/bolt/bolt/pull/6553