### PR TITLE
Remove trailing whitespace from cheatsheet.

### DIFF
--- a/cheatsheet.yml
+++ b/cheatsheet.yml
@@ -149,7 +149,7 @@ relations:
         You can use relationships between records by adding a relation to a ContentType. Relationships are always bidirectional.
     table:
         - [ "Example" ]
-        - [ "`relations:`<br>&nbsp;&nbsp;&nbsp;&nbsp;`pages:`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`multiple: false`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`label: Select a page`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`order: -id`"]  
+        - [ "`relations:`<br>&nbsp;&nbsp;&nbsp;&nbsp;`pages:`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`multiple: false`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`label: Select a page`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`order: -id`"]
     postfix: |
         Accessing `record.relation` will give you nothing but the ContentTypes and id’s: `{{ print(record.relation) }}`. To get the actual related records, use `{% set relatedrecords = record.related() %}`.
     links: { "Relationships in the docs": "contenttypes/relationships"}


### PR DESCRIPTION
Prevents docs from breaking under the latest symfony/yaml v3.2.7.

Before: 

![screen shot 2017-04-20 at 15 40 03](https://cloud.githubusercontent.com/assets/1833361/25234104/60adadd6-25e1-11e7-9106-632f6e82f954.png)
