### PR TITLE
Command "dump-autoloader" is not defined.

### DIFF
--- a/docs/upgrading/migrating-local-extensions-33.md
+++ b/docs/upgrading/migrating-local-extensions-33.md
@@ -66,7 +66,7 @@ For further information see the section of the Bundles documentation on
 [configuring autoloading][autoloading].
 
 <p class="note"><strong>Note:</strong> You must always remember to run
-<code>composer dump-autoloader</code> in your site's root directory after
+<code>composer dump-autoload</code> in your site's root directory after
 making any changes to the <code>"autoload"</code> section of your site's
 <code>composer.json</code>.</p>
 


### PR DESCRIPTION
Just sayin':

```
 [Symfony\Component\Console\Exception\CommandNotFoundException]
  Command "dump-autoloader" is not defined.
  Did you mean one of these?
      dumpautoload
      dump-autoload
```