### PR TITLE
Remove ext-mbstring as a requirement.

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -25,7 +25,6 @@ are default settings, and Bolt should work out-of-the-box.
     - curl
     - gd
     - json
-    - mbstring
     - opcache (optional)
     - posix
     - xml

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -24,8 +24,10 @@ are default settings, and Bolt should work out-of-the-box.
     - openssl
     - curl
     - gd
+    - intl (optional but recommended)
     - json
-    - opcache (optional)
+    - mbstring (optional but recommended)
+    - opcache (optional but recommended)
     - posix
     - xml
     - fileinfo


### PR DESCRIPTION
Goes with https://github.com/bolt/bolt/pull/6748