### PR TITLE
Update Bundled Extension Activation

### DIFF
--- a/docs/extensions/bundled/activation.md
+++ b/docs/extensions/bundled/activation.md
@@ -29,7 +29,7 @@ To clarify, the value you put in the yml file is exactly what you would use to
 instantiate the class, so in code the above is equivalent to
 `new \BundleBaseNamespace\MyBundleExtension()`
 
-An example using `.bolt.php`
+`.bolt.php` allows for two different methods of loading, via strings:
 
 ```php
 <?php
@@ -40,3 +40,14 @@ return [
 ];
 ```
 
+or via class instances:
+```php
+<?php
+
+use BundleBaseNamespace\MyBundleExtension;
+
+return [
+    'extensions' => [
+        new MyBundleExtension()
+    ]
+];```

--- a/docs/extensions/bundled/activation.md
+++ b/docs/extensions/bundled/activation.md
@@ -33,12 +33,9 @@ An example using `.bolt.php`
 
 ```php
 <?php
-
-use BundleBaseNamespace\MyBundleExtension;
-
 return [
     'extensions' => [
-        new MyBundleExtension()
+        'BundleBaseNamespace\MyBundleExtension'
     ]
 ];
 ```


### PR DESCRIPTION
Current 3.3 documentation shows that .bolt.php should return an array of new instances of bundled extensions to load. In reality this should actually be an array of fully-qualified class names.