### PR TITLE
Updating links to github, without the `release/`.

### DIFF
--- a/view/templates/_versionselect.twig
+++ b/view/templates/_versionselect.twig
@@ -38,7 +38,7 @@
         </select>
 
         <a class="button edit-github middle" target="_blank"
-        href="https://github.com/bolt/docs/blob/release/{{ version }}/docs/{{ page.path }}">
+        href="https://github.com/bolt/docs/blob/{{ version }}/docs/{{ page.path }}">
             <img src="/images/github.png">
             <span>Edit on GitHub</span>
         </a>

--- a/view/templates/index.twig
+++ b/view/templates/index.twig
@@ -76,7 +76,7 @@
             <a href="http://slack.bolt.cm/" target="_blank">Slack</a> or on
             <a href="http://bolt.cm/irc" target="_blank">IRC</a>.<br>
             Spotted a typo, or have something to add?
-            <a href="https://github.com/bolt/docs/blob/release/{{ version }}/docs/{{ page.path }}" target="_blank">Edit this page on GitHub</a>.
+            <a href="https://github.com/bolt/docs/blob/{{ version }}/docs/{{ page.path }}" target="_blank">Edit this page on GitHub</a>.
         </div>
 
 


### PR DESCRIPTION
Needs to go in with #778