### PR TITLE
add template select to list of fields

### DIFF
--- a/docs/fields/index.md
+++ b/docs/fields/index.md
@@ -21,6 +21,7 @@ pages:
     - imagelist
     - filelist
     - geolocation
+    - templateselect
 ---
 
 Introduction to Bolt Field Types


### PR DESCRIPTION
I know this page exist under the template section. But it is not obvious.

Thinking contextually If I am looking for documentation on templateselect field type. I would go to the field types page and not the templateing section.
