### PR TITLE
Updating 'flat files' and 'manual extraction' sections.

### DIFF
--- a/docs/howto/troubleshooting-outside-webroot.md
+++ b/docs/howto/troubleshooting-outside-webroot.md
@@ -55,7 +55,7 @@ install Bolt:
 ```bash
 curl -O https://bolt.cm/distribution/bolt-latest-flat-structure.tar.gz
 tar -xzf bolt-latest-flat-structure.tar.gz --strip-components=1
-php app/nut setup:sync
+php app/nut init
 ```
 
 This version of Bolt has the following structure, you can place entirely inside
@@ -80,9 +80,17 @@ This will result in a structure that looks like this.
         └── index.php
 ```
 
-Note: This version of Bolt is provided as a fallback for users who have no
-control over their web server setup. If at all possible, we strongly recommend
-to use the 'regular' version, with all code outside of the web root.
+<p class="note"><strong>Note:</strong> If you extract the <code>.zip</code>
+manually, in order to upload via (S)FTP, make sure you've completed the last
+step of the installation: Renaming the dist files, so Bolt can use them. See
+the section on renaming files on the page <a
+href="../installation/manual-download-and-extraction">Manual download and
+extraction</a>.</p>
+
+<p class="note"><strong>Note:</strong> This version of Bolt is provided as a
+fallback for users who have no control over their web server setup. If at all
+possible, we strongly recommend to use the 'regular' version, with all code
+outside of the web root.</p>
 
 Option 3: Create a symlink to the `public` folder
 -------------------------------------------------

--- a/docs/installation/manual-download-and-extraction.md
+++ b/docs/installation/manual-download-and-extraction.md
@@ -12,6 +12,20 @@ Download the latest version of Bolt as the regular or flattened distribution:
 Extract the `.zip` file, and you can start developing locally, or upload the
 files to your webhost using the (S)FTP client of your choice.
 
+If you extract the file yourself, you'll also need to manually complete a step
+of the installation that's normally done automatically by the installation
+process: Rename some files so bolt can use them.
+
+| Original name                              | Rename to       |            |
+| ------------------------------------------ | --------------- | ---------- |
+| `.bolt.yml.dist`                           | `.bolt.yml`     |
+| `composer.json.dist`                       | `composer.json` | (optional)
+| `composer.lock.dist`                       | `composer.lock` | (optional)
+| `src/Site/CustomisationExtension.php.dist` | `src/Site/CustomisationExtension.php`
+
+If you don't rename these files, Bolt will not be able to correctly detect the
+"root" of the site, and will show an error page instead.
+
 Tip: While it _is_ possible to upload the files to your webhost immediately,
 and configure Bolt as-you-go, it is **strongly** recommended to develop your site
 locally first. It's much quicker, you'll have a better overview of all that's
@@ -19,10 +33,9 @@ happening, and you can work on the project before it's accessible to the
 public. You can use either the [built-in server][built-in-server], or set up a
 development server using a free tool like [Xampp][xampp].
 
-
 <p class="note"><strong>Note:</strong> Don't forget to upload the
-<code>.htaccess</code> file, if you're using Apache! Bolt won't work without it.
-</p>
+<code>.htaccess</code> and <code>.bolt.yml</code> files, if you're using
+Apache! Bolt won't work without it. </p>
 
 If you can't find the file on your file system, download this
 [<code>default.htaccess</code>](https://bolt.cm/distribution/default.htaccess)
@@ -41,7 +54,6 @@ can use the so-called "[Flat distribution][flat]", as an alternative.
 
 If you wish to manually alter the directory structure, so it fits your needs
 better, see the section on [configuring Bolt's structure using `.bolt.yml`][bolt-yml].
-
 
 Next Steps
 ----------


### PR DESCRIPTION
For the "flat" distro, the `.bolt.yml` is required. However, if you manually extract it, `nut init` is not run, leaving you with `.bolt.yml.dist`. For those users who _both_ extract manually _and_ use the flat distro, i've expanded a bit on this in the docs. 