### PR TITLE
Use setZone() function to define the Widget Zone

### DIFF
--- a/docs/extensions/intermediate/web-assets.md
+++ b/docs/extensions/intermediate/web-assets.md
@@ -261,7 +261,7 @@ Widget classes have fluent setters for properties. e.g.
 protected function registerAssets()
 {
     $asset = new Widget();
-    $asset->setType(Zone::FRONTEND)
+    $asset->setZone(Zone::FRONTEND)
         ->setLocation(Target::WIDGET_FRONT_FOOTER)
         ->setCallback([$this, 'callbackWidget'])
         ->setCallbackArguments(['arg1' => 'Kenny', 'arg2' => 'Koala'])
@@ -282,7 +282,7 @@ public function callbackWidget($arg1, $arg2)
 ```
 
 In the above example:
-  * `setType(Zone::FRONTEND)` tells the asset injector to only act on the
+  * `setZone(Zone::FRONTEND)` tells the asset injector to only act on the
      frontend
   * `setLocation(Target::AFTER_META)` tells the asset injector to insert
      the snippet after other `<meta>`


### PR DESCRIPTION
Using setType() function is not possible. That function does not exist in [Widget.php](https://github.com/bolt/bolt/blob/3.4/src/Asset/Widget/Widget.php) but correct me if I'm wrong. 

I think this changes can be merged into 3.0 and up. 