### PR TITLE
Fix the color of "Search the documentation"

### DIFF
--- a/assets/scss/modules/_search.scss
+++ b/assets/scss/modules/_search.scss
@@ -2,6 +2,10 @@
 
 $search-height: 55px;
 
+.docs__sidebar--search label {
+    color: $menu-item-color;
+}
+
 .search{
    width: 100%;
    height: $search-height;


### PR DESCRIPTION
This is pretty untested, I don't have access to a proper system ATM, but the contrast levels between the label and the background were really annoying me :)