### PR TITLE
Move $name & $expire variables to correct constructor for filesystem.cache_factory

### DIFF
--- a/docs/performance/remote-filesystem/amazon-s3.md
+++ b/docs/performance/remote-filesystem/amazon-s3.md
@@ -254,9 +254,9 @@ class AwsServiceProvider implements ServiceProviderInterface
         $app['filesystem.cache_factory'] = $app->protect(
             function ($adapter, $name, $expire = null) {
                 // Note: Predis is use here as an example
-                $cache = new DoctrineCache(new PredisCache(new Predis\Client()));
+                $cache = new DoctrineCache(new PredisCache(new Predis\Client()), $name, $expire);
 
-                return new Cached($adapter, $cache, $name, $expire);
+                return new Cached($adapter, $cache);
             }
         );
 


### PR DESCRIPTION
$name & $expire params are part of DoctrineCache rather than the Cached adapter.