### PR TITLE
Removed 2nd "templateselect"

### DIFF
--- a/docs/fields/index.md
+++ b/docs/fields/index.md
@@ -12,7 +12,6 @@ pages:
     - markdown
     - textarea
     - repeater
-    - templateselect
     - block
     - integer
     - float


### PR DESCRIPTION
Templateselect appeared twice in the fields index, causing misbehaving pagination. Removed first instance.