### PR TITLE
Twig docs links from  Twig 1.x to Twig 2.x

### DIFF
--- a/docs/templating/building-templates.md
+++ b/docs/templating/building-templates.md
@@ -299,13 +299,13 @@ What happens in this example is the following:
 
 [twig]: http://twig.sensiolabs.org/documentation
 [twig-designers]: http://twig.sensiolabs.org/doc/templates.html
-[control-structure]: https://twig.sensiolabs.org/doc/1.x/templates.html#control-structure
-[twig-tags]: https://twig.sensiolabs.org/doc/1.x/tags/index.html
-[twig-filters]: https://twig.sensiolabs.org/doc/1.x/filters/index.html
-[twig-functions]: https://twig.sensiolabs.org/doc/1.x/functions/index.html
-[twig-tests]: https://twig.sensiolabs.org/doc/1.x/tests/index.html
-[tag-for]: https://twig.sensiolabs.org/doc/1.x/tags/for.html
-[tag-if]: https://twig.sensiolabs.org/doc/1.x/tags/if.html
-[tag-set]: https://twig.sensiolabs.org/doc/1.x/tags/set.html
-[tag-include]: https://twig.sensiolabs.org/doc/1.x/tags/include.html
-[tag-block]: https://twig.sensiolabs.org/doc/1.x/tags/extends.html#how-do-blocks-work
+[control-structure]: https://twig.sensiolabs.org/doc/templates.html#control-structure
+[twig-tags]: https://twig.sensiolabs.org/doc/tags/index.html
+[twig-filters]: https://twig.sensiolabs.org/doc/filters/index.html
+[twig-functions]: https://twig.sensiolabs.org/doc/functions/index.html
+[twig-tests]: https://twig.sensiolabs.org/doc/tests/index.html
+[tag-for]: https://twig.sensiolabs.org/doc/tags/for.html
+[tag-if]: https://twig.sensiolabs.org/doc/tags/if.html
+[tag-set]: https://twig.sensiolabs.org/doc/tags/set.html
+[tag-include]: https://twig.sensiolabs.org/doc/tags/include.html
+[tag-block]: https://twig.sensiolabs.org/doc/tags/extends.html#how-do-blocks-work


### PR DESCRIPTION
Example:
https://twig.symfony.com/doc/1.x/functions/index.html
changed to
https://twig.sensiolabs.org/doc/functions/index.html 
which will (currently) redirect to 
https://twig.symfony.com/doc/2.x/functions/index.html