### PR TITLE
Update usage of image filters.

### DIFF
--- a/docs/fields/image.md
+++ b/docs/fields/image.md
@@ -16,17 +16,19 @@ Simple image upload/select field.
 ## Example usage in templates:
 
 ```twig
-{{ record.cover|showimage() }}
+{{ record.values.cover|showimage() }}
 ```
 or
 ```twig
-{{ record.cover|thumbnail() }}
+{{ record.values.cover|thumbnail() }}
 ```
 or
 ```twig
-{{ record.cover|popup() }}
+{{ record.values.cover|popup() }}
 ```
 See [Bolt Template tags](../templating/twig-functionality) for more info.
+
+__Note:__ Using `record.values.cover` will display the `alt` attribute on the `img` tag, while simply using `record.cover` will not.
 
 ## Options:
 


### PR DESCRIPTION
Hi,

Most of my Bolts don't have any alts on `img` tags. Today I learned this is because the image filters must be used with `record.value.cover` not just `record.cover`.

Updating this part of the docs would probably save some time to a few.