### PR TITLE
adds documentation on using json manifest with the asset twig function

### DIFF
--- a/docs/templating/linking-in-templates.md
+++ b/docs/templating/linking-in-templates.md
@@ -70,7 +70,32 @@ This would produce, on an default install, the following output:
 <script src="/theme/base-2016/js/jquery.min.js"></script>
 
 <img src="/files/kitten.jpg">
+```  
+
+## Using `asset` and a JSON Manifest  
+
+Many build tools use a cache busting technique of outputting a hashed file (eg: `styles.abc12b89asdd.css`) along with a manifest referencing that file.  
+
+To use this technique - like with [Symfony's Webpack Encore](https://symfony.com/doc/current/frontend.html#frontend-webpack-encore) - you'll need to add a configuration block with the appropriate keys to either your `config.yml` or your (preferred) `config_local.yml` like the following:  
+
+```yaml  
+# using the asset package
+assets:
+   theme:
+        json_manifest_path: "/dist/manifest.json"
+        # the json_manifest is relative to your current theme.
+```  
+In your template you can now use your hashed assets by referencing the non-hashed file as follows:  
+
+```twig 
+<link rel="stylesheet" href="{{ asset('dist/css/styles.css', 'theme') }}">
+```  
+This will produce on a default install:  
+
+```html
+<link rel="stylesheet" href="/theme/base-2018/dist/css/styles.bbad62558ef19da7e0ca.css"> 
 ```
+  
 
 For a more in-depth description of the `asset` function, see the
 [Symfony documentation on assets][symfonyasset].

--- a/docs/templating/linking-in-templates.md
+++ b/docs/templating/linking-in-templates.md
@@ -74,7 +74,16 @@ This would produce, on an default install, the following output:
 
 ## Using `asset` and a JSON Manifest  
 
-Many build tools use a cache busting technique of outputting a hashed file (eg: `styles.abc12b89asdd.css`) along with a manifest referencing that file.  
+Many build tools use a cache busting technique of outputting a hashed file (eg: `styles.abc12b89asdd.css`) along with a manifest referencing that file.    
+
+This is an example manifest file:  
+
+```json
+{
+  "build/styles.css": "/dist/styles.abc12b89asdd.css",
+  "build/app.js": "/dist/app.2fec6da74d584bcd9fd2.js"
+}
+```
 
 To use this technique - like with [Symfony's Webpack Encore](https://symfony.com/doc/current/frontend.html#frontend-webpack-encore) - you'll need to add a configuration block with the appropriate keys to either your `config.yml` or your (preferred) `config_local.yml` like the following:  
 
@@ -84,7 +93,10 @@ assets:
    theme:
         json_manifest_path: "/dist/manifest.json"
         # the json_manifest is relative to your current theme.
-```  
+```   
+The ``theme`` key is a mount point you want to access your assets from. In this instance we are using the "theme" mount point/package name defined above in "package names". 
+
+
 In your template you can now use your hashed assets by referencing the non-hashed file as follows:  
 
 ```twig 


### PR DESCRIPTION
for https://github.com/bolt/bolt/issues/7483  

since this was added to bolt 3.5 this isn't available for all of 3.x series unfortunately 

relevant pull request where this was added https://github.com/bolt/bolt/pull/7305