### PR TITLE
Documentation for custom image attributes (Bolt PR 7743)

### DIFF
--- a/docs/fields/image.md
+++ b/docs/fields/image.md
@@ -35,17 +35,18 @@ field.
 
 * `extensions` Allows you to restrict users to only be able to upload files with
   certain file extensions.
-* `attrib` Can be set to a custom attribute, such as alt-texts, captions or data-attributes. For example:
+* `attrib` Can be set to a custom attribute, such as alt-texts, titles, captions or data-attributes. For example:
   * `alt` Show a text field for the `alt` parameter
-  * `caption` Show a text field for the `caption` parameter
-  * `[alt, caption]` Add more then one attribute
+  * `title` Show a text field for the `title` parameter
+  * `caption` Show a custom field for a `caption` this image uses in your template
+  * `[alt, title, caption]` Add more then one attribute
 * `upload` Allows you to upload files for this field into a specified directory
   so they remain grouped. This directory will be created in `{%web%}/files/`
 
 ```yaml
         cover:
             type: image
-            attrib: [alt, caption]
+            attrib: [alt, title, caption]
             extensions: [ gif, jpg, png ]
             upload: portfolio
 ```

--- a/docs/fields/image.md
+++ b/docs/fields/image.md
@@ -38,8 +38,8 @@ field.
 * `attrib` Can be set to a custom attribute, such as alt-texts, titles, captions or data-attributes. For example:
   * `alt` Show a text field for the `alt` parameter
   * `title` Show a text field for the `title` parameter
-  * `caption` Show a custom field for a `caption` this image uses in your template
-  * `[alt, title, caption]` Add more then one attribute
+  * `caption` Show a custom field for a `caption` that image will use in your template
+  * `[alt, title, caption]` Add more than one attribute
 * `upload` Allows you to upload files for this field into a specified directory
   so they remain grouped. This directory will be created in `{%web%}/files/`
 

--- a/docs/fields/image.md
+++ b/docs/fields/image.md
@@ -35,21 +35,21 @@ field.
 
 * `extensions` Allows you to restrict users to only be able to upload files with
   certain file extensions.
-* `attrib` Can be set to either of the following:
+* `attrib` Can be set to a custom attribute, such as alt-texts, captions or data-attributes. For example:
   * `alt` Show a text field for the `alt` parameter
-  * `title` Show a text field for the `title` parameter
-  * `[title, alt]` Show both fields
+  * `caption` Show a text field for the `caption` parameter
+  * `[alt, caption]` Add more then one attribute
 * `upload` Allows you to upload files for this field into a specified directory
   so they remain grouped. This directory will be created in `{%web%}/files/`
 
 ```yaml
         cover:
             type: image
-            attrib: [title, alt]
+            attrib: [alt, caption]
             extensions: [ gif, jpg, png ]
             upload: portfolio
 ```
 
-You can call these in your templates by using `{{ record.values.image.title }}`
-or `{{ record.values.image.alt }}` and they will also be automatically used by
+You can call these in your templates by using `{{ record.values.image.alt }}`
+or `{{ record.values.image.caption }}` and they will also be automatically used by
 bolt's image functions.


### PR DESCRIPTION
Adds documentation for the custom attributes for imagefields.
Goes with: https://github.com/bolt/bolt/pull/7743