### PR TITLE
Update Bolt API link

### DIFF
--- a/docs/core-development/index.md
+++ b/docs/core-development/index.md
@@ -14,7 +14,7 @@ This section aims to provide helpful information for people contributing to the
 development of Bolt.
 
 <div class="docsintro">
-    <a href="https://docs.bolt.cm/api/bolt/bolt/%%VERSION%%/" class="button medium docsintro">
+    <a href="https://docs.bolt.cm/api/bolt/bolt/3.x/" class="button medium docsintro">
         Bolt Core API docs (draft)<br>
         <small>(auto-generated)</small>
     </a>


### PR DESCRIPTION
Old one https://docs.bolt.cm/api/bolt/bolt/3.6/ gives 404

Closes #949 