### PR TITLE
Updated documentation for .bolt.yml regarding view

### DIFF
--- a/docs/howto/troubleshooting-outside-webroot.md
+++ b/docs/howto/troubleshooting-outside-webroot.md
@@ -168,7 +168,7 @@ paths:
     web: www
     themebase: www/theme
     files: www/files
-    view: www/bolt-public/view
+    view: www/bolt-public
 ```
 
 The result in the folder will look like this:
@@ -251,7 +251,7 @@ paths:
     web: .
     themebase: theme
     files: files
-    view: bolt-public/view
+    view: bolt-public
 ```
 
 Finally, edit `index.php`, so the bootstrapping can load successfully. Find the


### PR DESCRIPTION
If view is set to bolt-public/view, the layout does not work at all. Removing /view from this entry, solves the issue. (Which makes sense, because there is no "view" directory in bolt-public.)
It is also mentioned in this answer: https://discuss.bolt.cm/d/298-changing-folder-paths-for-database-config-etc/4