### PR TITLE
add missing doc about using json manifest with asset function

### DIFF
--- a/docs/templating/linking-in-templates.md
+++ b/docs/templating/linking-in-templates.md
@@ -72,12 +72,50 @@ This would produce, on an default install, the following output:
 <img src="/files/kitten.jpg">
 ```
 
+## Using `asset` and a JSON Manifest  
+
+Many build tools use a cache busting technique of outputting a hashed file (eg: `styles.abc12b89asdd.css`) along with a manifest referencing that file.    
+
+This is an example manifest file:  
+
+```json
+{
+  "build/styles.css": "/dist/styles.abc12b89asdd.css",
+  "build/app.js": "/dist/app.2fec6da74d584bcd9fd2.js"
+}
+```
+
+To use this technique - like with [Symfony's Webpack Encore](https://symfony.com/doc/current/frontend.html#frontend-webpack-encore) - you'll need to add a configuration block with the appropriate keys to either your `config.yml` or your (preferred) `config_local.yml` like the following:  
+
+```yaml  
+# using the asset package
+assets:
+   theme:
+        json_manifest_path: "/dist/manifest.json"
+        # the json_manifest is relative to your current theme.
+```   
+The ``theme`` key is a mount point you want to access your assets from. In this instance we are using the "theme" mount point/package name defined above in "package names". 
+
+
+In your template you can now use your hashed assets by referencing the non-hashed file as follows:  
+
+```twig 
+<link rel="stylesheet" href="{{ asset('dist/css/styles.css', 'theme') }}">
+```  
+This will produce on a default install:  
+
+```html
+<link rel="stylesheet" href="/theme/base-2018/dist/css/styles.bbad62558ef19da7e0ca.css"> 
+```
+  
+
 For a more in-depth description of the `asset` function, see the
 [Symfony documentation on assets][symfonyasset].
 
 <p class="note"><strong>Note:</strong> This function replaces the deprecated
 <code>{{ paths }}</code> template variable. As such, it's encouraged to use this
 function instead.</p>
+
 
 ## Linking to the current page
 


### PR DESCRIPTION
that doc was previously created and merged in https://github.com/bolt/docs/pull/944
but was never merged into 3.X and 3.6 branch...