### PR TITLE
Rewriting the documentation to easily step-by-step (cue NKOTB) ...

### DIFF
--- a/docs/configuration/introduction.md
+++ b/docs/configuration/introduction.md
@@ -3,49 +3,58 @@ title: Setting up Bolt
 ---
 
 
-After installation you can run the `bin/console bolt:setup` command, that will
-set up the database and the first user. You can then log in to the Bolt
-backend. You should now see Bolt's Dashboard screen.
+**1** After installation, run `bin/console bolt:setup`
 
-If this is not the case, but you see an error page instead, see below for a
-number of possible causes and solutions.
+This will set up the database and the first user.
 
-By default, Bolt is configured to use an SQLite database. See
-[configure the database](database), if you want to change this to either MySQL
-or PostgreSQL.
+**2** Login to the Bolt backend on `yourdomain.ext/bolt`
 
-<p class="note"><strong>Note:</strong> When you first open any Bolt page in your
-browser, you will be redirected to a page like <tt>/bolt/userfirst</tt> where
-you can set up the first user. If you get a 'File not found'-error, this means
-your web server isn't configured to handle rewrites correctly. If you're using
-Apache, see our page on <a href="../howto/making-sure-htaccess-works">Making
-sure .htaccess and mod_rewrite are working as they should</a>.</p>
+You should now see Bolt's Dashboard screen.
 
-### Permissions (reminder)
+<p class="tips"><strong>Tip:</strong> The Bolt backend is located at
+<code>/bolt</code>, relative from the 'home' location of your website.</p>
 
-Bolt needs to be able to write data to a number of folders like `cache/` and
-`files/`, where uploaded images and other files will be saved. If your server
-needs to have the permissions set manually, you'll notice when opening your new
-install in a browser window, because you will greeted by an error. If this
-happens, see our [File System Permissions](permissions) page on how to fix this.
+If you get an error, see below for a number of possible causes and solutions.
 
-If you want to get a quick way to see how your site looks with some content you
-can add some generated pages using the built-in [Loripsum](http://loripsum.net)
-tool. This is a simple method to test-drive your theme quickly.
-
-<p class="tip"><strong>Tip:</strong> The geolocation fields requires you
-set an api key, for more info see the comment in the main config and
-[this guide](https://developers.google.com/maps/documentation/javascript/get-api-key#get-an-api-key)
-for how to get a key</p>
-
+### Internal Server Errors
 If you're getting unspecified "Internal Server Errors", the most likely cause
 is a missing or malfunctioning `.htaccess` file. See the section [Tweaking the
-.htaccess file](../installation/webserver/apache) for tips. If you still
-encounter errors, check your vhost configuration and be sure that the
-AllowOverride option is enabled.
+.htaccess file](../installation/webserver/apache) for tips.
 
-<p class="tip"><strong>Tip:</strong> The Bolt backend is located at
-<code>/bolt</code>, relative from the 'home' location of your website.</p>
+If you still
+encounter errors, check your vhost configuration and be sure that the
+`AllowOverride` option is enabled.
+
+### Permissions errors
+
+If you get an error when opening your new install in a browser window, your server might need to have the permissions set manually.
+See our [File System Permissions](permissions) page on how to fix this.
+
+( Bolt needs to write data to a number of folders like `cache/` and
+`files/`, where uploaded images and other files will be saved. )
+
+## Database
+
+By default, Bolt is configured to use an SQLite database. See
+[configure the database](database), if you want to change this to MySQL
+or PostgreSQL.
+
+<p class="tips"><strong>Tip</strong> When you first open any Bolt page in your
+browser, you will be redirected to a page like <tt>/bolt/userfirst</tt> to set up the first user.
+<br>
+<br>If you get a 'File not found'-error, you'll most likely have a <em>rewrites</em> error. See <a href="../howto/making-sure-htaccess-works">this page on .htaccess and mod_rewrite on apache </a> for help.</p>
+
+### Fill with test content
+You can generate some test content using the built-in [Loripsum](http://loripsum.net)
+tool. This is a simple method to test-drive your theme quickly.
+
+The geolocation fields requires you to set an api key, for more info see the comment in the main config and [this guide](https://developers.google.com/maps/documentation/javascript/get-api-key#get-an-api-key)
+for how to get a key.
+
+
+
+
+
 
 Configuration Files
 -------------------
@@ -58,83 +67,86 @@ All files use the same YAML syntax, and can also be edited via the Bolt backend.
 
 | YAML file                     | Description |
 | ----------------------------- | ----------- |
-| `config/bolt/config.yml`       | The file where all general configuration of your website is defined.
-| `config/bolt/contenttypes.yml` | The definitions of your contenttypes, e.g. pages, blog items etc.
-| `config/bolt/menu.yml`         | The file that contains the menu(s) for your website.
+| `config/bolt/config.yml`       | General configuration of your website.
+| `config/bolt/contenttypes.yml` | The definitions of your contenttypes (pages, blog items etc.)
+| `config/bolt/menu.yml`         | Configuration of the menu(s) for your website.
 | `config/bolt/taxonomy.yml`     | Categories, chapters, tags etc. are defined here.
-| `config/bolt/routing.yml`      | The file where you can define custom urls for your website.
-| `config/bolt/permissions.yml`  | Here you can specify groups, users, etc. For most websites, the default permissions settings will be just fine.
+| `config/bolt/routing.yml`      | Configure custom urls for your website.
+| `config/bolt/permissions.yml`  | Specify usergroups, users and their permissions here. For most websites, the default settings will be just fine.
 
 There are two other locations where configuration files can be found:
 
 | Folder                   | Description |
 | ------------------------ | ----------- |
-| `config/bolt/extensions/` | If you install extensions, their config files will be located in this directory.
+| `config/bolt/extensions/` | Config files of your installed extensions
 | `public/theme/`          | In the folder for the active theme, there can optionally be a `theme.yml`.
 
-To access the values in these files in your templates or PHP code, you'll need
-to access them. This is described in detail in the sections "Accessing
-Configuration in PHP" and "Accessing Configuration in Twig" on the page
-[Accessing & Reading Configuration][config-accessing].
+To use the values in these files in your templates or PHP code, you'll need
+to access them. See [Accessing & Reading Configuration][config-accessing] for more info.
 
 ### Different configurations per environment
 
-When you have multiple environments for the same site, like development,
-staging, or production, you'll want parts of the config to be the same, and
-some different per environment. You'll probably have different database info
-and debug settings. This can be accomplished by splitting the `config.yml`
-file. Put all settings you share over all environments in the default
+Create a `config_local.yml` in the `config/bolt/` folder for settings that are only used on specific environments.
+
+**Shared settings:** Put all settings you share over all environments in the default
 `config.yml`, you can commit this in your version control system if wanted.
+
+**Specific settings:**
 Every setting which is different per environment, or which you do not want in
-version control (like database info), you put in `config_local.yml`. First
+version control (like database and debug info), you put in `config_local.yml`. First
 `config.yml` is loaded and then `config_local.yml`, so  that `config_local.yml`
 can override any setting in `config.yml`.
 
-**Note:**
+
+<p class="tips">
 Bolt will always load `config_local.yml` if it's available, so committing it to
 version control isn't recommended, and be sure not to deploy it to a server it
-is not needed on.
+is not needed on.</p>
 
-<p class="tip"><strong>Tip:</strong> You might want to disable <code>debug</code> in
+<p class="tip"><strong>Tip:</strong> Disable <code>debug</code> in
 <code>config.yml</code> and only enable <code>debug</code> in <code>config_local.yml</code>
 on development servers.</p>
 
 ### Dynamic values for config settings
 
-Occasionally you may want to set the value of a config setting dynamically at the
+You can also set the value of a config setting dynamically at the
 application runtime, rather than have it hardcoded in a config file.
 
-To take advantage of this feature you can surround the value with `%` characters
-and the value will then be looked up from the main Application container.
+Surround the value with `%` characters and the value will then be looked
+up from the main Application container.
 
-As a simple example the Bolt version is set as a value on the app container,
-you can access it normally with `$app['bolt_version']` if you wanted to use
-this as a dynamic config variable you could do the following in `config.yml`
+####Simple example
+
+The Bolt version is set as a value on the app container.
+You would normally access it with `$app['bolt_version']`.
+To use it as a dynamic config variable add the following to `config.yml`:
 
 ```
 mycustomversion: %bolt_version%
 ```
 
-after compilation the value of `{{ config.get('mycustomversion') }}` will match
+After compilation the value of `{{ config.get('mycustomversion') }}` will match
 the value set on the main application container.
 
-Note that at this point only string values are supported.
+**Note:** at this point only string values are supported.
 
-Note that configuration settings are namespaced. `{{ config.get('mycustomversion') }}`
-may not be necessarily available in your Twig templates directly. For more information
-regarding this, please refer to the [Bolt Internals](../internals/container-service-references#app-config)
-documentation. In this particular example, use `{{ config.get('general/mycustomversion') }}`
+Configuration settings are namespaced. `{{ config.get('mycustomversion') }}`
+may not be necessarily available in your Twig templates directly. In this particular example, use `{{ config.get('general/mycustomversion') }}`
 to access the above variable in your template.
+
+For more information
+regarding this, see the [Bolt Internals](../internals/container-service-references#app-config)
+documentation.
 
 ### Environment variables in config files
 
 You can use environment variables in your configuration files, such as
 `config.yml`.
 
-How this works is described in detail in the section "Reading environment
+Find detailed info on this in the section "Reading environment
 variables" on the page [Accessing & Reading Configuration][config-env].
 
-### Regarding Chrome and backend authentication
+### Bug: Chrome and backend authentication
 
 If you are using Chrome and using a IP based path, e.g. `192.168.60.10/public/bolt`,
 unfortunately you will not be able to log in.

--- a/docs/getting-started/about.md
+++ b/docs/getting-started/about.md
@@ -4,39 +4,57 @@ title: About Bolt
 About Bolt
 ==========
 
-Bolt is a tool for Content Management, which strives to be as simple and
-straightforward as possible. It is quick to set up, easy to configure, uses
-elegant templates, and above all: it's a joy to use. Bolt is created using
-modern Open Source libraries, and is best suited to build sites in HTML5, with
+Bolt is a CMS, which strives to be as simple and straightforward as possible.
+It is quick to set up, easy to configure, uses elegant templates, and above all: it's a joy to use.
+
+It is made using modern Open Source libraries, and is best suited to build sites in HTML5 with
 modern markup.
 
-Basically, there are three groups of users we've created Bolt for:
+Bolt is created for:
 
- - End users (read 'editors') that want to focus on producing and editing
-   content, and not on clicking buttons in the CMS.
- - Front-end designers and developers who like to write clean markup, and who
-   want to build websites where the CMS doesn't dictate what the templates or
-   site should look like.
- - Developers who need a system that's easy to set up and configure, that's
-   easy to manage and maintain, but is also flexible and versatile.
+ - **End users** (read 'editors') that focus on producing and editing
+   content.
+ - **Front-end developers / designers** who want to set up websites where the CMS is
+  flexible and easy to implement.
+ - **Developers** who need a system that's easy to manage, flexible and versatile.
 
-Using Bolt as a content editor: you don't have to know anything about HTML,
-CSS, PHP or any of the other technical stuff we used to build Bolt. Using Bolt
-should be about writing and editing content, so that's the focus of Bolt's user
-interface. Far more information about how Bolt works can be found in the
-[User manual](../manual).
 
-Building a website with Bolt: we assume you have the usual Frontender skills.
-You know HTML/CSS, and have working knowledge about JavaScript so you can
-implement things like Google Analytics trackers, jQuery plugins and such. To
-create a working site out of your static HTML, you'll need to know about how
-Bolt uses Content and ContentTypes, and how to make templates using Twig.
-Information about those topics can be found in the chapters
-[ContentTypes](../contenttypes/intro) and
-[Building templates](../templating/building-templates).
+###End users / Editors
 
-With creating Bolt we wanted to focus on creating something simple,
-straightforward and enjoyable. Bolt concentrates on being a content management
-system with a small footprint. Out of the box it may not offer all of the
-features of larger systems, but, being built on modular, loosely coupled
-components it can be an ideal foundation for projects large and small.
+As a content editor, using Bolt is about writing and editing content.
+So we optimized of Bolt's user interface to make it clear and user friendly.
+You don't have to know anything about HTML, CSS or other code, just start creating content.
+
+<p class="tips">
+  <strong>Getting started for editors:</strong>
+  <br>
+  <a href="../manual">User Manual</a>
+</p>
+
+###Front-end developers / designers
+You know HTML/CSS and some basic JavaScript. To create a working site out of your static HTML, you'll need to know about the building blocks of Bolt.
+
+<p class="tips">
+  <strong>Getting started for front-end developers and designers:</strong>
+  <br>
+  <a href="../contenttypes/intro">ContentTypes</a><br>
+  <a href="../templating/building-templates">Building templates</a>
+</p>
+
+###Developers
+You have a knowledge of Symfony and you want to customize a Bolt website to your exact needs. You'll want to know about configuring bolt and how to create extensions.
+
+<p class="tips">
+  <strong>Getting started for developers:</strong>
+  <br>
+  <a href="../configuration/introduction">Configuring Bolt</a><br>
+  <a href="../extensions/introduction">Introduction to extensions</a>
+</p>
+
+Creating Bolt, we wanted to focus on creating something simple,
+straightforward and enjoyable.
+
+Bolt concentrates on being a content management
+system with a small footprint. Being built on modular, loosely coupled
+components it is an ideal foundation for projects large and small.
+

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -4,15 +4,13 @@ title: Requirements
 Requirements
 ============
 
-The system requirements for Bolt are modest, and it should run on any fairly
-modern web server.
+###System requirements
 
   - PHP 7.1.3 or higher
   - Access to SQLite (which comes bundled with PHP), _or_ MySQL _or_
     PostgreSQL
 
-The PHP installation has a few additional requirements. On most servers these
-are default settings, and Bolt should work out-of-the-box.
+###PHP requirements
 
   - A minimum of 32MB of memory allocated to PHP
   - The following common PHP extensions:
@@ -32,39 +30,38 @@ are default settings, and Bolt should work out-of-the-box.
     - exif
     - zip
 
-Note: The following PHP modules are known to conflict with Bolt and it's
-underlying Symfony components, and must be disabled:
+The following PHP modules are known to conflict with Bolt and it's
+underlying Symfony components, and must be **disabled**:
 
   - Zend Guard Loader
   - ionCube
 
-<p class="note"><strong>Note:</strong> A Bolt server must be accessible by a
-host name, or fully qualified domain name (FQDN), otherwise authentication will
-not work. Using `localhost` as the host name should also work.
-</br></br>
-For developing sites, it is often useful to add a custom host name for the
-development server to your local computer's hosts file.</p>
+<p class="tips"><strong>Tips:</strong> A Bolt server must be accessible by a
+host name or fully qualified domain name (FQDN), for authentication to work.
+Using `localhost` as the host name also works.
+<br><br>
+For developing sites, you may add a custom host name for the
+development server to your own hosts file.</p>
 
 Webserver
 ---------
 
-During development you can run Bolt using PHP's built-in webserver, the
+**Development:** You can run Bolt using PHP's built-in webserver, the
 [Symfony][cli] client, Docker, XAMPP, MAMP, or pretty much whatever you're used
-to. \
-To run a Bolt site in production, you'll need apache with `mod_rewrite`
-<strong>enabled</strong> (`.htaccess` files) or Nginx. See the chapter on
-[webserver configuration][webserver] for details.
+to.
+
+**Production:** To run a Bolt site in production, you'll need apache with `mod_rewrite`
+<strong>enabled</strong> (`.htaccess` files) or Nginx. See [webserver configuration][webserver] for details.
 
 Browser requirements
 --------------------
 
-The Bolt backend was designed and built to work optimally in any modern
-browser, both on Desktop and Mobile. Internet Explorer is not really supported.
-Use Edge, Firefox or Chrome.
+**Bolt backend:** The Bolt backend is built to work optimally in any modern
+browser, both on Desktop and Mobile.
 
-<p class="note"><strong>Note:</strong> These requirements are completely
-separated for websites that are built with Bolt. The templates that Bolt uses,
-are developed the way you want them to be.</p>
+**Sites built in Bolt:** The browser requirements are completely separated for websites that are built with Bolt.
+The websites you build on Bolt can be modified to be supported in any browser you want.
+
 
 [webserver]: installation/webserver/nginx
 [cli]: https://symfony.com/download


### PR DESCRIPTION
... and scannable docs.

The 4.0 docs are now still mainly (wall of) text based, which is good as a start. But to make it easy for reference we want to add more headers, steps, examples, short sentences and whitespace. This is a work in progress.