### PR TITLE
Update PHP Requirements

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -7,7 +7,7 @@ Requirements
 The system requirements for Bolt are modest, and it should run on any fairly
 modern web server.
 
-- PHP 7.2.5 or higher
+- PHP 7.3 or higher
 - Access to SQLite (which comes bundled with PHP), _or_ MySQL _or_
     PostgreSQL
 


### PR DESCRIPTION
After updating from RC7 to RC10, I got the following error starting bolt: "Fatal Error: composer.lock was created for PHP version 7.3 or higher".  I assume some dependency updated that now requires this higher PHP version.