### PR TITLE
Update Relationships Documentation

### DIFF
--- a/docs/contenttypes/relationships.md
+++ b/docs/contenttypes/relationships.md
@@ -8,6 +8,11 @@ You can define relationships between records by adding a relation to
 `contenttypes.yml`.
 
 ```yaml
+pages:
+    name: Pages
+    singular_name: Page
+    [..]
+
 entries:
     name: Entries
     singular_name: Entry
@@ -16,17 +21,18 @@ entries:
     relations:
         pages:
             multiple: false
-            label: Select a page
+            required: false
+            label: Select a related page
             order: -id
     [..]
 ```
 
-The `relations` are defined by the slug of the ContentType that it's related to.
-In the example above `pages`. It takes a few parameters:
+The `relations` are defined by the `slug` of the ContentType that it's related to. If a slug is not explicitly defined for a ContentType, the `name` is used. In the example above, it is `pages`. It takes a few parameters:
 
 | Parameter  | Description |
 |------------|-------------|
-| `multiple` | `true` or `false`, to indicate whether the user can pick one related record, or more than one. |
+| `required` | `true` or `false`, to determine if the user must pick a related record. Defaults to `true`. |
+| `multiple` | `true` or `false`, to indicate whether the user can pick one related record, or more than one.  Defaults to `false`. |
 | `label` | The label to show on the edit screen. |
 | `order` | The order in which the items are listed on the edit screen. This can be any field in the ContentType. Prefix with `-` to reverse the sorting. In the case of the example, `-id` means that the records that were created last are at the top.
 | `format` | How to show the titles for each record that can be selected. This takes a twig string where `item` is the record that can be selected.  For example if you have two fields for firstname and lastname you might put `'{{item.firstname}} {{item.lastname}}'` here. The default is `'{{ item.title|escape }} (№ {{ item.id }})'` |
@@ -46,36 +52,10 @@ If you see this, you might consider adding the reverse relation to the
 
 Relations in templates
 ----------------------
-
-Internally, relations are stored and accessible in the `Bolt\Record` object.
-However, accessing `record.relation` will give you nothing but the ContentTypes
-and id's:
+To get the related records in twig, use the _filter_ `related`.
 
 ```
-    {{ dump(record.relation) }}
-```
-
-Output:
-
-```
-arr(2)
-[
-    "pages"        => arr(1)
-        [
-            0 => str(2) "45"
-        ]
-    "kitchensinks" => arr(2)
-        [
-            0 => str(2) "12"
-            1 => str(2) "23"
-        ]
-]
-```
-
-To get the actual related records, use the _function_ `related()`
-
-```
-    {% set relatedrecords = record.related() %}
+    {% set relatedrecords = record|related %}
     {% if relatedrecords is not empty %}
         <p>Related content:</p>
         <ul>
@@ -85,35 +65,3 @@ To get the actual related records, use the _function_ `related()`
         </ul>
     {% endif %}
 ```
-
-The `related()` function has two optional parameters. If you don't pass any
-parameters, you will get all related records, regardless of their ContentType.
-To retrieve only the related records of a specific ContentType, use:
-
-```
-    {% set relatedrecords = record.related('pages') %}
-```
-
-To request only one specific related record, pass the id as the second
-parameter:
-
-```
-    {% set relatedrecords = record.related('pages', 45) %}
-```
-
-To use pagination in a list of related records, use the ids of the related
-records in a `setcontent` tag:
-
-```
-    {% set ids = record.relation.news|join(" || ") %}
-    {% setcontent messages = "news" where { id: ids } allowpaging limit 6 %}
-    {% for item in messages %}
-    ...
-    {% endfor %}
-    {{ pager('news') }}
-```
-
-<p class="note"><strong>Note:</strong> The <code>related()</code> function
-<em>always</em> returns an array of records, even if you request only a single
-record. In general, it's best to always use a <code>{% for %}</code>-loop, to
-iterate over the results.</p>


### PR DESCRIPTION
* Clarified the contenttypes.yml example, and how relations are associated
* Add information about the "required" option
* Update templating example to use the "related" twig filter
* Remove the paragraph about the "relation" property on the content (this no longer exists)
* Remove the paragraph about the "related()" twig function (this no longer exists)