### PR TITLE
fixed homepage menu item && current item syntax

### DIFF
--- a/docs/menus/custom.md
+++ b/docs/menus/custom.md
@@ -14,7 +14,7 @@ Some of the more commonly used 'tricks' are:
     first item in the loop.
   - `{% if loop.last %}last{% endif %}` - Output `last`, but only for the last
     item in the loop.
-  - `{% if item|current %}active{% endif %}` - Output `current`, but only if
+  - `{% if item.current %}active{% endif %}` - Output `active`, but only if
     we're on the page that the item links to.
   - `{% if item.title is defined %}title='{{ item.title|escape }}'{% endif %}`
     - Add a `title` attribute, but only if it's defined in our `.yaml`-file, or

--- a/docs/menus/dynamic.md
+++ b/docs/menus/dynamic.md
@@ -41,7 +41,7 @@ Now all that's left is to modify your submenu template (`_sub_menu.twig`) so tha
     {% from _self import display_menu_item %}
     {% apply spaceless %}
     <li class="index-{{ loop.index -}}
-        {{ item.path|default('') == 'homepage' ? ' menu-text' -}}
+        {{ item.path|default('') == '/' ? ' menu-text' -}}
         {{ loop.first ? ' first' -}}
         {{ loop.last ? ' last' -}}
         {{ (item.submenu|default(false) and withsubmenus) ? ' is-dropdown-submenu-parent' -}}

--- a/docs/menus/index.md
+++ b/docs/menus/index.md
@@ -22,7 +22,7 @@ options:
 main:
   - label: Home
     title: This is the first menu item. Fo shizzle!
-    path: homepage
+    path: /
     class: first
   - path: entry/1
     label: Second item
@@ -61,4 +61,3 @@ the intended one:
 Much more information on rendering menus in your templates can be found on the page on [menus in the Twig Components section][twig].
 
 [twig]: ../twig-components/menu
-


### PR DESCRIPTION
When I used `{% item|current ? %}` as stated in the docs I ran into following error:
```
Argument 2 passed to Bolt\Twig\ContentExtension::isCurrent() must be an instance of Bolt\Entity\Content, array given
[...]
at Bolt\Twig\ContentExtension->isCurrent(object(Environment), array('label' => 'Home', 'link' => 'homepage', 'submenu' => null, 'uri' => '/', 'current' => false))
```
When I use `{% item.current ? %}`, it works. So I guess this might be an error in the docs... Or is it my config?

Also, fixed the output, as that should say 'active'.