### PR TITLE
doc:  "Default settings for thumbnails" seems to be a title

### DIFF
--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -227,7 +227,7 @@ Can be overridden for each content type.
 records_per_page: 8
 ```
 
-Default settings for thumbnails.
+### Default settings for thumbnails
 
 | Option          | Description |
 |-----------------|-------------|


### PR DESCRIPTION
This seems to be a title, should be easier to link this part of the doc to someone.