### PR TITLE
Small typo in twig example

### DIFF
--- a/docs/templating/content-fetching.md
+++ b/docs/templating/content-fetching.md
@@ -255,7 +255,7 @@ practice to limit the maximum number of records, by adding a `limit` clause.
 
 ```twig
 {# get 10 pages created by 'bob' #}
-{% setcontent mypages = 'pages' where { author: getuser('bob').ud } limit 10 %}
+{% setcontent mypages = 'pages' where { author: getuser('bob').id } limit 10 %}
 ```
 
 Paginating results


### PR DESCRIPTION
I think Github is changing the last line, I didn't change it ¯\_(ツ)_/¯