### PR TITLE
Add nginx config restriction exception for letsencrypt

### DIFF
--- a/docs/installation/webserver/nginx.md
+++ b/docs/installation/webserver/nginx.md
@@ -148,7 +148,7 @@ your Bolt sites on a host.
 ```nginx
 # Block access to "hidden" files
 # i.e. file names that begin with a dot "."
-location ~ /\. {
+location ~ /\.(?!well-known) {
     deny                          all;
 }
 

--- a/docs/installation/webserver/nginx.md
+++ b/docs/installation/webserver/nginx.md
@@ -148,6 +148,7 @@ your Bolt sites on a host.
 ```nginx
 # Block access to "hidden" files
 # i.e. file names that begin with a dot "."
+# An exception is included for Let's Encrypt ssl verification
 location ~ /\.(?!well-known) {
     deny                          all;
 }


### PR DESCRIPTION
Let's Encrypt's http challenge uses `.well-known/acme-challenge/xxxx` for verification

Denying access to everything starting with a dot was causing my certificate renewal to fail.