### PR TITLE
Delete reference to has_sortorder

### DIFF
--- a/docs/contenttypes/intro.md
+++ b/docs/contenttypes/intro.md
@@ -233,7 +233,7 @@ The available options are:
 | `listing_template` | The default template to use, when displaying an overview of Records of this ContentType. The template itself should be located in your `theme/foo/` folder, in Bolt's root folder. |
 | `listing_records` <small>(optional)</small> | The amount of records to show on a single overview page in the frontend. If there are more records, the results will be paginated   |
 | `listing_sort` <small>(optional)</small> | The field used to sort the results on. You can reverse the order by adding a '-'. For example `title` or `-datepublish`. |
-| `sort` <small>(optional)</small> | The default sorting of this ContentType, in the overview in Bolt's backend interface. For example `-datecreated`. Note that if your ContentType has a Taxonomy with `has_sortorder`, that the `sort` will be overruled by the Taxonomy's sorting. |
+| `sort` <small>(optional)</small> | The default sorting of this ContentType, in the overview in Bolt's backend interface. For example `-datecreated`. |
 | `records_per_page` <small>(optional)</small> | The amount of records shown on each page in the Bolt backend. If there are more records, they will be paginated. |
 | `show_on_dashboard` <small>(optional)</small> | When set to `false` the ContentType will not appear in the 'Recently edited &hellip;' list on the dashboard page. |
 | `show_in_menu` <small>(optional)</small> | When set to `false` the ContentType will show in a submenu instead of as a top level menu. Can also be set to a word or sentence to group ContentTypes under different menus. |


### PR DESCRIPTION
I think `has_sortorder` was something from Bolt 3 which has not been implemented in Bolt 4 (yet?). 
FYI there's also 2 references in https://docs.bolt.cm/4.0/contenttypes/taxonomies