### PR TITLE
Add title block to example to prevent errors

### DIFF
--- a/docs/extensions/pages.md
+++ b/docs/extensions/pages.md
@@ -69,6 +69,10 @@ For example, the `content_user.html.twig` file may contain the following:
 ```twig
 {% extends '@bolt/_base/layout.html.twig' %}
 
+{% block title %}
+   This is the title of the page
+{% endblock %}
+
 {% block main %}
     <p>This is the content for a user. It is currently empty.</p>
 {% endblock %}


### PR DESCRIPTION
If the title block is not added and a developer uses this example they will see an error saying that the title block does not exist.

This PR prevents other developers bumping into this.