### PR TITLE
Update taxonomy config access prefix

### DIFF
--- a/docs/configuration/reading.md
+++ b/docs/configuration/reading.md
@@ -47,7 +47,7 @@ These prefixes are:
 | `menu`         | `menu.yaml`
 | `permissions`  | `permissions.yaml`
 | `routing`      | `routing.yaml`
-| `taxonomy`     | `taxonomy.yaml`
+| `taxonomies`   | `taxonomy.yaml`
 | `theme`        | `theme.yaml` (in the active theme directory)
 
 "General" refers to the main configuration found in `config.yaml`. 


### PR DESCRIPTION
The prefix to access Taxonomy config (taxonomy.yaml) seems to be `taxonomies` instead of `taxonomy`.