### PR TITLE
Update Bolt 4.0 docs `recordsperpage` example

### DIFF
--- a/docs/contenttypes/intro.md
+++ b/docs/contenttypes/intro.md
@@ -407,7 +407,7 @@ pages:
         <<: *content_defaults
         <<: *template_defaults
     taxonomy: [ chapters ]
-    recordsperpage: 100
+    records_per_page: 100
 ```
 
 Keeping fields together in a group


### PR DESCRIPTION
Ensures we note the correct (new) syntax for the `records_per_page` content type parameter.