### PR TITLE
Add "image" twig method docs to Bolt5 upgrade

### DIFF
--- a/docs/upgrading/upgrading-from-30.md
+++ b/docs/upgrading/upgrading-from-30.md
@@ -288,3 +288,17 @@ In Bolt 5 the syntax is:
 ```twig
 {% apply spaceless %} - {% endapply %} 
 ``` 
+
+#### Twig image function
+
+In Bolt 3, you could render an image using the `image` function in your theme's twig templates:
+
+```twig
+<img src="{{ image(record.image, 600, 500) }}" alt="{{ record.imagealt }}" />
+```
+
+In Bolt 4.x and up, the new syntax is:
+
+```
+<img src="{{ showimage(record.image, 600, 500) }}" alt="{{ record.imagealt }}" />
+```


### PR DESCRIPTION
Sigh. We missed this note on the Bolt 3.x to Bolt5 upgrade doc. Thankfully, it was easy to find in the "Twig changes in Bolt 4" doc.

Have a random MonkeyUser comic :smiley: 

![Testing in a nutshell](https://www.monkeyuser.com/assets/images/2017/59-testing-in-a-nutshell.png)