### PR TITLE
warn about reserved assets package names

### DIFF
--- a/docs/howto/encore-setup.md
+++ b/docs/howto/encore-setup.md
@@ -85,6 +85,8 @@ After making this change you can reference your assets like this if you've copie
 {{ asset('my-assets/images/home-map.png', 'my-site') }}
 ```
 
-Here 'my-site' refers to the 'my-site' under packages in `assets.yaml`
+Here 'my-site' refers to the 'my-site' under packages in `assets.yaml`[^1].
+[^1]: Note, somes packaged "names" are reserved (because already defined by bolt), like : "bolt", "theme", "public" and "files"
+
 
 Build your files using encore (yarn ...), and refresh the page!


### PR DESCRIPTION
Is could be tempting (as I did) to use the "theme" assets package name (instead of "my-site). But the config is never effective because it's overriden by bolt "TwigAwareController"  which defined some twig packages (used internally by the {{ asset() }} function), see TwigAwareController line 206 for details...

reserved packages names are : "bolt" / "theme" / "public" and "files"