### PR TITLE
Fix name of "extensions:configure" docs page

### DIFF
--- a/docs/console-command/extensions/extensions-configure.md
+++ b/docs/console-command/extensions/extensions-configure.md
@@ -1,12 +1,12 @@
 ---
-title: extensions:setup
+title: extensions:configure
 level: intermediate
 ---
 extensions:configure
 ================
 
-Console's `extensions:configure` command sets-up extension configuration,
-services and routes.
+Console's `extensions:configure` command sets up extension configuration,
+services and routes by copying the extension default configuration into your Bolt site `config/` directory.
 
 ## Usage
 


### PR DESCRIPTION
... plus add a bit more explanation about what this command _actually_ does.