### PR TITLE
Change image options attrib: title to alt: true

### DIFF
--- a/docs/contenttypes/intro.md
+++ b/docs/contenttypes/intro.md
@@ -376,7 +376,7 @@ __nodes:
     content_defaults: &content_defaults
         image:
             type: image
-            attrib: title
+            alt: true
         body:
             type: html
             height: 300px


### PR DESCRIPTION
attrib is not found among the options of the type image field.
deprecated? alt: true is a good alternative here to maintain consistency

Issue Nr:  #1239