### PR TITLE
Remove deprecated instructions about template fields

### DIFF
--- a/docs/manual/fieldtypes.md
+++ b/docs/manual/fieldtypes.md
@@ -303,8 +303,7 @@ Bolt-specific fields
 
 <a href="https://user-images.githubusercontent.com/7093518/91534734-556b4d00-e912-11ea-8b2f-1452ed3204cf.png" class="popup"><img src="https://user-images.githubusercontent.com/7093518/91534734-556b4d00-e912-11ea-8b2f-1452ed3204cf.png"></a><br>
 
-Allows one to choose a specific template for each particular record. Can add
-additional fields by using the feature "Template specific fields".
+Allows one to choose a specific template for each particular record.
 
 ### Slug
 

--- a/docs/templating/building-templates.md
+++ b/docs/templating/building-templates.md
@@ -154,7 +154,7 @@ The current default theme contains the following files and folders:
 | `partials/_header.twig` | Helper template that gets included as the header. |
 | `partials/_footer.twig` | Helper template that gets included as the footer. |
 | `partials/_recordfooter.twig` | Footer specifically for ContentType records |
-| `theme.yaml` | A file with configuration related to the theme and how it works with bolt. Can also contain configuration for template specific fields and values for the theme to use in its templates. |
+| `theme.yaml` | A file with configuration related to the theme and how it works with bolt. Can also contain configuration for the theme to use in its templates. |
 | `js/` | Compiled JavaScript files |
 | `css/` | Compiled CSS files |
 


### PR DESCRIPTION
Bolt had in version 3.x a feature allowing to add template fields.

According to @bobdenotter this feature does not exist anymore, thus I propose removing the information about specific template fields in the documentation.